### PR TITLE
Website: Digital Legacy + Product Tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-09-19
+
+- Introduced Torvus Digital Legacy hero, /digital-legacy explainer, and product tier pricing pages with updated navigation.
+- Added analytics instrumentation for GA4/PostHog, refreshed security/trust copy, and generated new Open Graph imagery.
+
 ## 2024-10-04
 
 - Rebuilt marketing site with App Router pages, self-hosted fonts, and CSP enforcement.

--- a/app/(site)/digital-legacy/opengraph-image.tsx
+++ b/app/(site)/digital-legacy/opengraph-image.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable import/no-unused-modules */
+
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default function DigitalLegacyOg() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontFamily: "'Satoshi', 'Inter', 'sans-serif'",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #0B1220 0%, #26619C 55%, #1AAE9F 100%)",
+          color: "#FFFFFF",
+          padding: "80px",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+          <div
+            style={{
+              width: "48px",
+              height: "48px",
+              background: "#D61F69",
+              clipPath: "polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)",
+            }}
+          />
+          <div style={{ fontSize: "42px", fontWeight: 600 }}>Torvus Digital Legacy</div>
+        </div>
+        <div
+          style={{
+            maxWidth: "760px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "24px",
+          }}
+        >
+          <div style={{ fontSize: "66px", fontWeight: 600, lineHeight: 1.1 }}>
+            Estate orchestration with death verification, executors, and provenance.
+          </div>
+          <div
+            style={{ fontSize: "28px", color: "rgba(229,231,235,0.92)", lineHeight: 1.4 }}
+          >
+            Inventory assets, capture intent, and release them only when policy-backed
+            checks confirm it’s time.
+          </div>
+        </div>
+        <div style={{ fontSize: "26px", fontWeight: 500, color: "#BBF7D0" }}>
+          torvussecurity.com/digital-legacy
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/app/(site)/digital-legacy/page.tsx
+++ b/app/(site)/digital-legacy/page.tsx
@@ -1,56 +1,82 @@
-import {
-  CalendarClock,
-  ClipboardList,
-  KeyRound,
-  Layers3,
-  UsersRound,
-} from "lucide-react";
 import Link from "next/link";
 
-import { IconChip } from "@/components/icon-chip";
-import { PhoneMock } from "@/components/phone-mock";
+import { AnalyticsEvent } from "@/components/analytics-event";
+import { SectionIntro } from "@/components/section-intro";
 import { PrimarySubtleLink, buttonClasses } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { createMetadata } from "@/lib/metadata";
 
 import type { Metadata } from "next";
 
 export const revalidate = 86400;
 
-const scope = [
+const capabilities = [
   {
-    icon: ClipboardList,
     title: "Asset inventory & intent capture",
-    body: "Map passwords, documents, media, crypto keys, and messages. Define who should receive each asset and under what circumstances.",
+    body: "Catalogue accounts, archives, crypto wallets, and instructions. Attach context and successor notes that stay encrypted until release.",
   },
   {
-    icon: UsersRound,
-    title: "Legacy agents",
-    body: "Assign trusted agents or executors. Early access focuses on human verification; KYC/IDV integrations arrive in the roadmap.",
+    title: "Legacy agents & executor KYC",
+    body: "Nominate trusted people or professionals. Torvus verifies their identity and keeps them in readiness mode with periodic check-ins.",
   },
   {
-    icon: CalendarClock,
     title: "Death verification predicate",
-    body: "Combine inactivity windows, notarised certificates, and third-party attestations before any estate release proceeds.",
+    body: "Blend inactivity timers, human attestations, and probate evidence before estate mode begins. Manual review today, registry integrations tomorrow.",
   },
   {
-    icon: Layers3,
     title: "Estate mode orchestrator",
-    body: "Bundle assets by recipient, generate checklists, and stage releases over time so sensitive data arrives when it’s actionable.",
+    body: "Stage releases per recipient with checklists, provenance certificates, and redaction controls. Executors stay accountable across every step.",
   },
   {
-    icon: KeyRound,
     title: "Optional crypto key handover",
-    body: "Support threshold handover for wallets and seed phrases. Split keys between recipients and professional custodians.",
+    body: "Distribute Shamir-style threshold splits. No single party ever holds the full secret without the quorum you define.",
+  },
+  {
+    title: "Duress pause",
+    body: "Freeze timers, alert trusted contacts, and optionally serve decoy material without tipping off a coercive actor.",
+  },
+  {
+    title: "Recipient verification",
+    body: "Recipients must pass passkey-first authentication or high-assurance fallbacks before any data decrypts.",
+  },
+  {
+    title: "Audit & provenance",
+    body: "Every action emits a tamper-evident certificate so families, lawyers, and auditors can prove what happened and when.",
   },
 ];
 
-const roadmap = [
-  "Executor and beneficiary workspaces with collaborative approvals.",
-  "Structured KYC and biometrics for high-assurance estate transfers.",
-  "Notary and legal firm integrations for witness signatures.",
-  "API webhooks to sync estate state with trust & estate platforms.",
-  "Regional data residency controls beyond Australia and the EU.",
+const tiers = [
+  {
+    id: "individual",
+    name: "Torvus Individual",
+    summary: "Free or low-cost core, ideal for personal estates and family archives.",
+    features: [
+      "Digital Legacy basics with guided inventory templates.",
+      "Two executors with email and passkey verification.",
+      "Standard audit history and provenance receipts.",
+    ],
+  },
+  {
+    id: "professional",
+    name: "Torvus Professional",
+    summary: "For journalists, NGOs, and estate planners who need advanced policies.",
+    features: [
+      "Advanced policy composer with multi-signal predicates.",
+      "Executor and recipient KYC with redaction-ready dry runs.",
+      "Extended audit exports and integration hooks.",
+    ],
+  },
+  {
+    id: "enterprise",
+    name: "Torvus Enterprise",
+    summary:
+      "Custom programs for organisations with regulated or high-assurance requirements.",
+    features: [
+      "Custom estate-mode workflows, attestations, and reporting.",
+      "SSO/SAML, delegated administration, and bespoke onboarding.",
+      "Dedicated support with DPA/BAA options.",
+    ],
+  },
 ];
 
 export const metadata: Metadata = createMetadata({
@@ -63,127 +89,84 @@ export const metadata: Metadata = createMetadata({
 export default function DigitalLegacyPage() {
   return (
     <div className="pb-24">
-      <section className="relative overflow-hidden border-b border-storm/10 bg-gradient-to-br from-white via-pastel-lapis/30 to-white pt-[var(--section-pt)] pb-[var(--section-pb)]">
+      <AnalyticsEvent event="dl_page_view" pagePath="/digital-legacy" />
+      <section className="relative overflow-hidden border-b border-storm/10 bg-gradient-to-br from-white via-pastel-lapis/40 to-white pt-[var(--section-pt)] pb-[var(--section-pb)]">
         <div
-          className="pointer-events-none absolute -right-20 top-6 h-56 w-56 rounded-full bg-lapis/25 blur-[130px]"
+          className="pointer-events-none absolute -right-24 top-12 h-80 w-80 rounded-full bg-pastel-lapis/50 blur-[160px]"
           aria-hidden="true"
         />
-        <div className="container relative flex flex-col items-center gap-16 lg:flex-row lg:items-start lg:justify-center">
-          <div className="relative order-2 w-full max-w-xl space-y-8 rounded-xl bg-white/92 p-6 shadow-soft-1 lg:order-1 lg:mr-12">
-            <div className="flex flex-col gap-4">
-              <p className="text-[0.95rem] font-semibold uppercase tracking-[0.26em] text-lapis">
-                Digital Legacy
-              </p>
-              <h1 className="text-gradient-lapis max-w-[20ch] text-display font-semibold text-storm">
-                Handover what matters with proof, empathy, and control
-              </h1>
-              <p className="max-w-[65ch] text-lead text-thunder">
-                Torvus Digital Legacy orchestrates estate logistics when you’re
-                gone—without sacrificing the privacy your work requires today. Executors
-                receive clarity, while intent and audit trails stay intact.
-              </p>
-            </div>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <PrimarySubtleLink
-                href="/waitlist"
-                className="min-w-[180px] sm:whitespace-nowrap"
-              />
-              <Link
-                href="/contact"
-                className={buttonClasses({
-                  variant: "secondary",
-                  size: "lg",
-                  className:
-                    "whitespace-nowrap border-lapis/45 text-lapis hover:bg-pastel-lapis/35",
-                })}
-              >
-                Talk with our team
-              </Link>
-            </div>
-            <p className="max-w-[65ch] text-[0.95rem] text-thunder">
-              Co-designing with estate planners, fiduciaries, and digital security teams.
-            </p>
-            <div className="mt-6 grid gap-2 text-[0.95rem] text-thunder">
-              {[
-                {
-                  copy: "Asset inventory and intent capture",
-                  icon: "key" as const,
-                },
-                {
-                  copy: "Executor collaboration with checklists",
-                  icon: "users" as const,
-                },
-                {
-                  copy: "Death-verification predicates and estate mode orchestration",
-                  icon: "timer" as const,
-                },
-                {
-                  copy: "Optional threshold key handover",
-                  icon: "shield" as const,
-                },
-              ].map(({ copy, icon }) => (
-                <IconChip key={copy} tone="lapis" icon={icon}>
-                  {copy}
-                </IconChip>
-              ))}
-            </div>
+        <div className="container relative space-y-8">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+            Digital Legacy
+          </p>
+          <h1 className="text-display font-semibold text-storm">
+            Digital Legacy, by Torvus
+          </h1>
+          <p className="max-w-prose text-lead text-thunder">
+            A privacy-first digital estate platform that inventories assets, verifies
+            executors, and releases information only when your policy says it’s time.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+              Join the waitlist
+            </PrimarySubtleLink>
+            <Link
+              href="/pricing"
+              className={buttonClasses({
+                variant: "secondary",
+                size: "sm",
+                className: "border-lagoon/45 text-lagoon",
+              })}
+            >
+              Compare tiers
+            </Link>
           </div>
-          <div className="order-1 flex flex-col items-center gap-8 lg:order-1 lg:items-center">
-            <div className="relative flex w-full max-w-[320px] justify-center rounded-xl border border-lapis/35 bg-white/85 p-6 shadow-soft-2">
-              <div
-                className="pointer-events-none absolute inset-0 rounded-xl bg-[linear-gradient(145deg,rgba(38,97,156,0.18),rgba(14,32,68,0.16))] opacity-80"
-                aria-hidden="true"
-              />
-              <PhoneMock scheme="light" accent="lapis" />
-            </div>
-            <div className="relative w-full max-w-[320px] overflow-hidden rounded-lg border border-lapis/35 bg-white/92 p-6 shadow-soft-1">
-              <div
-                className="pointer-events-none absolute inset-0 bg-grad-panel opacity-60"
-                aria-hidden="true"
-              />
-              <div className="relative space-y-3">
-                <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
-                  Estate orchestrator
-                </p>
-                <h2 className="text-gradient-lapis text-h4 font-semibold text-storm">
-                  Bundle recipients into traceable, policy-backed checklists.
-                </h2>
-                <div className="grid gap-2 text-[1.02rem] text-thunder">
-                  {[
-                    "Executors verify identity before any release stage proceeds.",
-                    "Notary audits, attestations, and quorum approvals stay attached to each task.",
-                    "Executors and beneficiaries see provenance without exposing plaintext.",
-                  ].map((item, index) => (
-                    <IconChip
-                      key={item}
-                      tone={index === 0 ? "lapis" : index === 1 ? "lagoon" : "cranberry"}
-                      icon="check"
-                      className="text-left"
-                    >
-                      {item}
-                    </IconChip>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
+          <p className="max-w-prose text-[0.95rem] text-thunder">
+            Executors and beneficiaries always receive provenance records. Torvus
+            operators never see your plaintext.
+          </p>
         </div>
       </section>
 
       <section className="pt-[calc(var(--section-pt)*0.9)] pb-[calc(var(--section-pb)*0.9)]">
-        <div className="container space-y-10">
-          <h2 className="text-h3 font-semibold text-storm">v1 scope</h2>
-          <div data-card-list="ab" className="grid gap-6 md:grid-cols-2">
-            {scope.map((item) => (
-              <Card
-                key={item.title}
-                className="hover-card pressable border border-lapis/25 bg-white/92"
-              >
-                <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-lapis/15 text-lapis">
-                  <item.icon className="h-6 w-6" aria-hidden="true" strokeWidth={1.5} />
-                </div>
-                <h3 className="text-h4 font-semibold text-storm">{item.title}</h3>
-                <p className="text-body text-thunder">{item.body}</p>
+        <div className="container space-y-8">
+          <SectionIntro
+            title="What Digital Legacy is"
+            description="A verifiable, policy-driven estate release platform that protects your privacy today while preparing trusted handover for tomorrow."
+            eyebrow="Overview"
+          />
+          <div className="space-y-4 text-body text-thunder">
+            <p>
+              Torvus Digital Legacy combines encrypted asset storage with policy
+              orchestration. You decide who should receive each item, what verification
+              they must pass, and how long Torvus should wait before initiating release.
+            </p>
+            <p>
+              Executors receive checklists with provenance so they can evidence every step
+              without exposing secrets. You can pause, revise, or revoke at any time
+              before the policy is fulfilled.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="capabilities"
+        className="bg-gradient-to-br from-white via-mist/60 to-white py-[calc(var(--section-pt)*0.8)]"
+      >
+        <div className="container space-y-8">
+          <SectionIntro
+            eyebrow="Key capabilities"
+            title="The toolkit behind Digital Legacy"
+            description="From intent capture to duress response, each component is built for high-assurance release orchestration."
+          />
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {capabilities.map((item) => (
+              <Card key={item.title} className="border-storm/12">
+                <CardHeader>
+                  <CardTitle>{item.title}</CardTitle>
+                  <CardDescription>{item.body}</CardDescription>
+                </CardHeader>
               </Card>
             ))}
           </div>
@@ -192,33 +175,121 @@ export default function DigitalLegacyPage() {
 
       <section className="pt-[calc(var(--section-pt)*0.85)] pb-[calc(var(--section-pb)*0.85)]">
         <div className="container space-y-8">
-          <div className="relative overflow-hidden rounded-xl border border-storm/10 bg-white p-8 shadow-soft-1">
-            <div
-              className="pointer-events-none absolute inset-0 bg-grad-panel opacity-60"
-              aria-hidden="true"
-            />
-            <h2 className="text-gradient-hero text-h3 font-semibold text-storm">
-              Future roadmap
-            </h2>
-            <p className="mt-4 max-w-3xl text-lead text-thunder">
-              Digital Legacy continues to evolve with estate professionals and
-              fiduciaries. Here’s what is currently in flight.
+          <SectionIntro
+            eyebrow="Policy mechanics"
+            title="How the release policy works"
+            description="Policies combine inactivity thresholds, grace windows, and verification steps so no single signal can trigger estate mode."
+          />
+          <div className="grid gap-6 md:grid-cols-2">
+            {[
+              "Configure inactivity timers with reminders and escalation paths.",
+              "Require executor attestations, probate confirmation, or third-party verification before release.",
+              "Set grace windows to cancel or pause if circumstances change.",
+              "Simulate the policy end-to-end with dry runs before going live.",
+            ].map((item) => (
+              <div
+                key={item}
+                className="flex gap-3 rounded-2xl border border-storm/12 bg-white/95 p-5 shadow-soft-1"
+              >
+                <span
+                  className="mt-[0.3rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                  aria-hidden="true"
+                />
+                <span className="text-body text-thunder">{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-gradient-to-br from-white via-pastel-cranberry/25 to-white py-[calc(var(--section-pt)*0.8)]">
+        <div className="container space-y-8">
+          <SectionIntro
+            eyebrow="Security & privacy"
+            title="Engineered for zero-knowledge control"
+            description="Encryption at rest with customer-specific keys, hardware-backed KMS on the roadmap, and a zero-knowledge design so Torvus never handles your plaintext."
+          />
+          <div className="grid gap-4 text-body text-thunder">
+            <p>
+              Every vault item is encrypted client-side before it reaches Torvus. We
+              operate with strict separation between compute and key management, and
+              roadmap customer-managed keys via Hardware Security Modules.
             </p>
-            <ul className="mt-6 space-y-3 text-[1.02rem] text-thunder">
-              {roadmap.map((item) => (
-                <li key={item} className="flex items-start gap-2">
-                  <span
-                    className="mt-2 inline-block h-1.5 w-1.5 rounded-full bg-cranberry/70"
-                    aria-hidden="true"
-                  />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-            <p className="mt-6 text-[0.95rem] text-thunder">
-              Want to influence the roadmap? Email legacy@torvussecurity.com with context
-              about your estate planning workflows.
+            <p>
+              Provenance logs are tamper-evident and exportable. External auditors can
+              verify chain-of-custody without seeing sensitive content. Learn more on our{" "}
+              <Link href="/security" className="font-semibold text-lapis hover:underline">
+                Security page
+              </Link>
+              .
             </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="pt-[calc(var(--section-pt)*0.85)] pb-[calc(var(--section-pb)*0.85)]">
+        <div className="container space-y-10">
+          <SectionIntro
+            eyebrow="Tiers"
+            title="Choose the tier that meets your estate needs"
+            description="Start personal, upgrade for professional oversight, or partner with Torvus for enterprise rollouts."
+          />
+          <div className="grid gap-6 md:grid-cols-3">
+            {tiers.map((tier) => (
+              <Card key={tier.id} id={tier.id} className="h-full border-storm/12">
+                <CardHeader>
+                  <CardTitle>{tier.name}</CardTitle>
+                  <CardDescription>{tier.summary}</CardDescription>
+                </CardHeader>
+                <ul className="space-y-2 text-[0.95rem] text-thunder">
+                  {tier.features.map((feature) => (
+                    <li key={feature} className="flex gap-3">
+                      <span
+                        className="mt-[0.35rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                        aria-hidden="true"
+                      />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+              Join the waitlist
+            </PrimarySubtleLink>
+            <Link
+              href="https://platform.torvussecurity.com"
+              className="text-[0.95rem] font-semibold text-lapis hover:underline"
+            >
+              Go to platform signup
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-gradient-to-br from-white via-mist/60 to-white py-[calc(var(--section-pt)*0.8)]">
+        <div className="container space-y-8">
+          <SectionIntro
+            eyebrow="Get started"
+            title="Ready to prepare your Digital Legacy?"
+            description="Request access to the waitlist today. We’ll guide you through inventory, policy design, and executor onboarding."
+          />
+          <div className="flex flex-wrap items-center gap-4">
+            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+              Join the waitlist
+            </PrimarySubtleLink>
+            <Link
+              href="https://platform.torvussecurity.com"
+              className={buttonClasses({
+                variant: "tertiary",
+                size: "sm",
+                className: "border-lagoon/45 text-lagoon",
+              })}
+            >
+              Go to platform signup
+            </Link>
           </div>
         </div>
       </section>

--- a/app/(site)/pricing/page.tsx
+++ b/app/(site)/pricing/page.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+
+import { FAQ } from "@/components/faq";
+import { PricingTiers } from "@/components/pricing-tiers";
+import { SectionIntro } from "@/components/section-intro";
+import { PrimarySubtleLink } from "@/components/ui/button";
+import { createMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = createMetadata({
+  title: "Pricing",
+  description:
+    "Compare Torvus Individual, Professional, and Enterprise tiers for Digital Legacy, including policy orchestration, KYC, and audit features.",
+  path: "/pricing",
+});
+
+export default function PricingPage() {
+  return (
+    <div className="pb-24">
+      <section className="relative overflow-hidden border-b border-storm/10 bg-gradient-to-br from-white via-pastel-lagoon/35 to-white pt-[var(--section-pt)] pb-[var(--section-pb)]">
+        <div
+          className="pointer-events-none absolute left-[-10%] top-16 h-72 w-72 rounded-full bg-pastel-lagoon/60 blur-[160px]"
+          aria-hidden="true"
+        />
+        <div className="container relative space-y-6">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lagoon">
+            Pricing
+          </p>
+          <h1 className="text-display font-semibold text-storm">
+            Torvus plans for Digital Legacy
+          </h1>
+          <p className="max-w-prose text-lead text-thunder">
+            Select the tier that matches your estate workflow. Every plan keeps policies
+            encrypted, auditable, and verifiable.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+              Join the waitlist
+            </PrimarySubtleLink>
+            <Link
+              href="https://platform.torvussecurity.com"
+              className="text-[0.95rem] font-semibold text-lapis hover:underline"
+            >
+              Go to platform signup
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <PricingTiers />
+
+      <section
+        id="enterprise-contact"
+        className="bg-gradient-to-br from-white via-mist/60 to-white py-[calc(var(--section-pt)*0.7)]"
+      >
+        <div className="container space-y-8">
+          <SectionIntro
+            eyebrow="Contact sales"
+            title="Enterprise support when Digital Legacy is mission critical"
+            description="Tell us about your requirements—SSO/SAML, bespoke workflows, or compliance packages—and we’ll schedule a review."
+          />
+          <div className="grid gap-8 lg:grid-cols-2">
+            <div className="space-y-4 text-body text-thunder">
+              <p>
+                Email us at{" "}
+                <a
+                  className="font-semibold text-lapis hover:underline"
+                  href="mailto:security@torvussecurity.com"
+                >
+                  security@torvussecurity.com
+                </a>{" "}
+                or share details below. We respond within two business days.
+              </p>
+              <p>
+                Need early access instead? The{" "}
+                <Link
+                  href="/waitlist"
+                  className="font-semibold text-lapis hover:underline"
+                >
+                  waitlist
+                </Link>{" "}
+                ensures you’re first in line for Professional previews.
+              </p>
+            </div>
+            <form
+              className="space-y-4 rounded-3xl border border-storm/12 bg-white/95 p-6 shadow-soft-1"
+              method="post"
+              action="mailto:security@torvussecurity.com"
+            >
+              <div className="flex flex-col gap-1">
+                <label htmlFor="name" className="text-[0.9rem] font-semibold text-storm">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  autoComplete="name"
+                  required
+                  className="rounded-xl border border-storm/15 px-3 py-2 text-[0.95rem] text-storm shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="email" className="text-[0.9rem] font-semibold text-storm">
+                  Work email
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="rounded-xl border border-storm/15 px-3 py-2 text-[0.95rem] text-storm shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="requirements"
+                  className="text-[0.9rem] font-semibold text-storm"
+                >
+                  Requirements
+                </label>
+                <textarea
+                  id="requirements"
+                  name="requirements"
+                  rows={4}
+                  className="rounded-xl border border-storm/15 px-3 py-2 text-[0.95rem] text-storm shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon"
+                  placeholder="Let us know about team size, jurisdictions, and compliance needs."
+                />
+              </div>
+              <button
+                type="submit"
+                className="inline-flex w-full items-center justify-center rounded-full border border-lagoon/45 bg-lagoon/10 px-5 py-2 text-[0.95rem] font-semibold text-lagoon transition hover:border-lagoon/60 hover:bg-lagoon/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              >
+                Contact Torvus
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <FAQ />
+    </div>
+  );
+}

--- a/app/(site)/security/page.tsx
+++ b/app/(site)/security/page.tsx
@@ -36,7 +36,7 @@ const encryption = [
   },
   {
     title: "Key derivation & sealing",
-    body: "Per-item data keys are wrapped with envelope keys. Policy metadata (conditions, recipients, approvals) is sealed and integrity-protected to prevent tampering.",
+    body: "Per-item data keys are wrapped with envelope keys. Policy metadata (conditions, recipients, approvals) is sealed and integrity-protected to prevent tampering. Digital Legacy estates add staged KMS hardening with a customer-managed key roadmap.",
   },
   {
     title: "Split custody",
@@ -170,6 +170,12 @@ export default function SecurityPage() {
                 Split custody envelope keys with quorum and duress awareness
               </IconChip>
             </div>
+            <p className="mt-4 max-w-prose text-[0.95rem] text-thunder">
+              Digital Legacy release paths inherit the same controls: envelope keys reside
+              in segregated KMS clusters today with hardware-backed customer key
+              management on the roadmap, and every estate event produces provenance
+              receipts that executors and beneficiaries can independently verify.
+            </p>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <PrimarySubtleLink href="/waitlist" />
               <Link

--- a/app/(site)/trust/page.tsx
+++ b/app/(site)/trust/page.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+
+import { SectionIntro } from "@/components/section-intro";
+import { PrimarySubtleLink } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { createMetadata } from "@/lib/metadata";
+
+import type { Metadata } from "next";
+
+export const dynamic = "force-static";
+
+const trustLinks = [
+  {
+    title: "Security",
+    description:
+      "Zero-knowledge architecture, duress controls, and Digital Legacy safeguards.",
+    href: "/security",
+  },
+  {
+    title: "Privacy",
+    description: "How Torvus handles personal information and encrypted artefacts.",
+    href: "/legal/privacy",
+  },
+  {
+    title: "Terms",
+    description: "Service terms, acceptable use, and contractual posture.",
+    href: "/legal/terms",
+  },
+  {
+    title: "Status",
+    description: "Live uptime dashboard with incidents and maintenance notices.",
+    href: "/status",
+  },
+];
+
+export const metadata: Metadata = createMetadata({
+  title: "Trust Center",
+  description:
+    "Centralise how Torvus approaches security, privacy, compliance, and availability for Digital Legacy and the broader platform.",
+  path: "/trust",
+});
+
+export default function TrustPage() {
+  return (
+    <div className="pb-24">
+      <section className="relative overflow-hidden border-b border-storm/10 bg-gradient-to-br from-white via-pastel-lapis/25 to-white pt-[var(--section-pt)] pb-[var(--section-pb)]">
+        <div
+          className="pointer-events-none absolute right-[-12%] top-16 h-72 w-72 rounded-full bg-pastel-lagoon/50 blur-[150px]"
+          aria-hidden="true"
+        />
+        <div className="container relative space-y-8">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+            Trust Center
+          </p>
+          <h1 className="text-display font-semibold text-storm">
+            Transparency for Digital Legacy and beyond
+          </h1>
+          <p className="max-w-prose text-lead text-thunder">
+            Trust is built on clarity. Explore our security controls, privacy posture,
+            policies, and live status so you can validate Torvus for sensitive estate
+            orchestration.
+          </p>
+          <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+            Join the waitlist
+          </PrimarySubtleLink>
+        </div>
+      </section>
+
+      <section className="pt-[calc(var(--section-pt)*0.9)] pb-[calc(var(--section-pb)*0.9)]">
+        <div className="container space-y-8">
+          <SectionIntro
+            eyebrow="Resources"
+            title="Navigate our trust artefacts"
+            description="Find the right reference quickly—security deep dives, policy documents, and live uptime insights."
+          />
+          <div className="grid gap-6 md:grid-cols-2">
+            {trustLinks.map((link) => (
+              <Card key={link.href} className="border-storm/12 p-6">
+                <h2 className="text-h3 font-semibold text-storm">{link.title}</h2>
+                <p className="mt-2 text-body text-thunder">{link.description}</p>
+                <Link
+                  href={link.href}
+                  className="mt-4 inline-flex items-center gap-2 text-[0.95rem] font-semibold text-lapis hover:underline"
+                >
+                  Visit {link.title}
+                  <span aria-hidden="true">→</span>
+                </Link>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { AnalyticsScripts } from "@/components/analytics-scripts";
 import Footer from "@/components/footer";
 import Header from "@/components/header";
 import { StructuredData } from "@/components/structured-data";
@@ -29,6 +30,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" className={`${satoshi.variable} ${erode.variable}`}>
       <head>
         <StructuredData />
+        <AnalyticsScripts />
       </head>
       <body className="flex min-h-dvh flex-col bg-white font-sans text-[17px] text-thunder antialiased md:text-base">
         <a href="#main-content" className="skip-link">

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable import/no-unused-modules */
+
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontFamily: "'Satoshi', 'Inter', 'sans-serif'",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(135deg, #0B1220 0%, #1F2937 40%, #26619C 100%)",
+          color: "#FFFFFF",
+          padding: "80px",
+        }}
+      >
+        <div
+          style={{ display: "flex", alignItems: "center", gap: "20px", color: "#FFFFFF" }}
+        >
+          <div
+            style={{
+              width: "48px",
+              height: "48px",
+              background: "#D61F69",
+              clipPath: "polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)",
+            }}
+          />
+          <div style={{ fontSize: "42px", fontWeight: 600 }}>Torvus Security</div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "24px",
+            maxWidth: "720px",
+          }}
+        >
+          <div style={{ fontSize: "64px", fontWeight: 600, lineHeight: 1.1 }}>
+            Digital Legacy that protects intent and provenance.
+          </div>
+          <div
+            style={{ fontSize: "28px", lineHeight: 1.4, color: "rgba(229,231,235,0.9)" }}
+          >
+            Policy-driven vaults, executor verification, and duress-aware releases built
+            by Torvus.
+          </div>
+        </div>
+        <div style={{ fontSize: "26px", fontWeight: 500, color: "#A5F3FC" }}>
+          www.torvussecurity.com
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 
+import { Hero } from "@/components/hero";
 import { IconChip } from "@/components/icon-chip";
 import { Key, Shield, Timer, Users } from "@/components/icons";
-import { PhoneMock } from "@/components/phone-mock";
 import { SectionIntro } from "@/components/section-intro";
-import { PrimarySubtleLink, buttonClasses } from "@/components/ui/button";
+import { AudienceTiles, HowItWorksTiles } from "@/components/tiles";
+import { buttonClasses } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { createMetadata } from "@/lib/metadata";
 
@@ -15,155 +16,56 @@ export const dynamic = "force-static";
 const featureHighlights = [
   {
     icon: Timer,
-    title: "Dead-man switch policies",
-    body: "Compose inactivity windows, approval quorums, and conditional checks. If you don’t respond in time, Torvus orchestrates release without exposing plaintext to operators.",
+    title: "Policy-driven release",
+    body: "Compose inactivity thresholds, executor approvals, and context checks before anything unlocks. Estate mode runs only when your signals agree.",
   },
   {
     icon: Shield,
-    title: "Duress pause & safe fails",
-    body: "Trigger a silent pause that freezes releases, serves decoy content, or alerts a trusted contact without tipping off an observer. Every event lands in tamper-evident logs.",
+    title: "Duress pause & decoys",
+    body: "Trigger a covert pause, serve sanitised decoys, or redirect executors to human review without tipping off a coercive actor.",
   },
   {
     icon: Users,
     title: "Recipient verification",
-    body: "Bind recipients to verified identities and enforce passkeys or TOTP fallback. Zero-knowledge retrieval flows ensure only intended parties unwrap sealed data.",
+    body: "Passkeys first, TOTP fallback when necessary. Every recipient must prove identity before Torvus unwraps sealed data.",
   },
   {
     icon: Key,
-    title: "Digital Legacy orchestration",
-    body: "Inventory critical artefacts, capture intent, and automate estate handover with policy-backed key splits. Executors receive transparent, verifiable checklists.",
+    title: "Provenance everywhere",
+    body: "Every step writes tamper-evident audit trails so beneficiaries and legal teams can prove what was released and when.",
   },
 ];
 
 export const metadata: Metadata = createMetadata({
-  title: "Protect people by protecting their information.",
+  title: "Digital Legacy that respects privacy and intent.",
   description:
-    "Torvus Security is a policy-driven vault with zero-trust encryption, duress controls, and auditable provenance so sensitive work only unlocks when it should.",
+    "Introduce Torvus Digital Legacy: a policy-driven vault that inventories assets, verifies executors, and orchestrates estate releases with audit-backed provenance.",
   path: "/",
 });
 
 export default function HomePage() {
   return (
     <div className="pb-24">
-      <section className="relative overflow-hidden border-b border-white/10 pt-[var(--section-pt)] pb-[var(--section-pb)]">
-        <div
-          className="pointer-events-none absolute -left-32 top-12 h-64 w-64 rounded-full bg-cranberry/25 blur-[140px]"
-          aria-hidden="true"
-        />
-        <div className="container relative flex flex-col items-center gap-16 lg:flex-row lg:items-start lg:justify-center">
-          <div className="order-1 space-y-7 rounded-xl border border-white/60 bg-white p-7 shadow-[0_20px_50px_rgba(11,18,32,0.12)] lg:max-w-xl">
-            <p className="text-[0.95rem] font-semibold uppercase tracking-[0.26em] text-cranberry">
-              Policy-based vaulting
-            </p>
-            <h1 className="text-gradient-hero max-w-[18ch] text-display font-semibold">
-              Protect people by protecting their information.
-            </h1>
-            <p className="max-w-[65ch] text-lead text-thunder">
-              Torvus seals sensitive disclosures behind conditional policies with live
-              duress controls and independently verifiable provenance.
-            </p>
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <PrimarySubtleLink href="/waitlist" className="whitespace-nowrap" />
-              <Link
-                href="/product"
-                className={buttonClasses({
-                  variant: "tertiary",
-                  size: "sm",
-                  className: "border-lagoon/45 text-lagoon",
-                })}
-              >
-                Explore the product
-              </Link>
-            </div>
-            <p className="max-w-[65ch] text-[0.95rem] text-thunder">
-              Built with zero-knowledge encryption, Australian Privacy Principles, and
-              GDPR high-assurance workflows in mind.
-            </p>
-            <div className="mt-6 grid gap-2 text-[0.95rem]">
-              {[
-                {
-                  copy: "Policy-based release with timers, approvals, and contextual checks",
-                  tone: "cranberry" as const,
-                  icon: "timer" as const,
-                },
-                {
-                  copy: "Duress pause and decoys that don’t tip off a coercive actor",
-                  tone: "lagoon" as const,
-                  icon: "shield" as const,
-                },
-                {
-                  copy: "Verified recipients using passkeys first with TOTP fallback when required",
-                  tone: "lapis" as const,
-                  icon: "users" as const,
-                },
-                {
-                  copy: "Provenance certificates captured for every unwrapping event",
-                  tone: "lagoon" as const,
-                  icon: "check" as const,
-                },
-              ].map(({ copy, tone, icon }) => (
-                <IconChip key={copy} tone={tone} icon={icon}>
-                  {copy}
-                </IconChip>
-              ))}
-            </div>
-          </div>
-          <div className="order-2 flex flex-col items-center gap-8 text-white lg:items-center">
-            <div className="relative flex w-full max-w-[320px] justify-center rounded-xl border border-white/20 bg-white/10 p-6 shadow-soft-2 backdrop-blur">
-              <div
-                className="pointer-events-none absolute inset-0 rounded-xl bg-[linear-gradient(135deg,rgba(214,31,105,0.32),rgba(38,97,156,0.22))] opacity-80"
-                aria-hidden="true"
-              />
-              <PhoneMock scheme="dark" accent="cranberry" />
-            </div>
-            <div className="relative w-full max-w-[320px] space-y-4 rounded-xl border border-white/60 bg-white p-6 shadow-[0_20px_50px_rgba(11,18,32,0.1)]">
-              <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-cranberry">
-                Recipient portal
-              </p>
-              <h2 className="text-gradient-accent text-h3 font-semibold text-storm">
-                Recipients stay verified before anything unlocks
-              </h2>
-              <p className="max-w-[65ch] text-[0.95rem] leading-relaxed text-[#1F2937]">
-                Passkeys and proofing confirm identities before Torvus unwraps sealed
-                keys. Every disclosure carries provenance your counterparts can trust.
-              </p>
-              <div className="space-y-2 text-[0.95rem] text-[#1F2937]">
-                <IconChip tone="lagoon" icon="users">
-                  Multi-factor retrieval with device fingerprinting
-                </IconChip>
-                <IconChip tone="lapis" icon="check">
-                  Automatic provenance certificates for every release
-                </IconChip>
-                <IconChip tone="cranberry" icon="shield">
-                  Checklist mode that keeps executors aligned and accountable
-                </IconChip>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+      <Hero />
+
+      <HowItWorksTiles />
 
       <section className="pt-[var(--section-pt)] pb-[var(--section-pb)]">
         <div className="container space-y-12">
           <SectionIntro
             eyebrow="Why Torvus"
-            title="Security architecture built around conditional trust"
+            title="Security architecture centred on conditional trust."
             description="Every component—from encryption keys to approval oracles—is designed so no single actor can leak secrets. Policies are auditable, recoverable, and testable before they matter."
             align="center"
           />
           <div data-card-list="ab" className="grid gap-6 md:grid-cols-2">
             {featureHighlights.map((feature) => (
-              <Card
-                key={feature.title}
-                className="hover-card pressable border border-storm/10 bg-white/92"
-              >
+              <Card key={feature.title} className="border-storm/12">
                 <CardHeader className="flex flex-col gap-4">
-                  <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-cranberry/15 text-cranberry">
+                  <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-pastel-cranberry/35 text-cranberry">
                     <feature.icon className="h-6 w-6" aria-hidden="true" />
                   </div>
-                  <CardTitle className="text-h4 font-semibold text-storm">
-                    {feature.title}
-                  </CardTitle>
+                  <CardTitle>{feature.title}</CardTitle>
                 </CardHeader>
                 <CardDescription>{feature.body}</CardDescription>
               </Card>
@@ -172,112 +74,99 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="overflow-hidden bg-gradient-to-br from-white via-pastel-lapis/20 to-white py-[calc(var(--section-pt)*0.75)]">
+      <AudienceTiles />
+
+      <section className="pt-[calc(var(--section-pt)*0.8)] pb-[calc(var(--section-pb)*0.8)]">
         <div className="container grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:items-center">
           <div className="space-y-6">
-            <p className="text-[0.95rem] font-semibold uppercase tracking-[0.26em] text-lapis">
-              Torvus Digital Legacy
+            <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lagoon">
+              Digital Legacy, powered by Torvus
             </p>
-            <h2 className="text-gradient-accent text-h3 font-semibold text-storm">
-              Protect intent today while preparing controlled disclosures for tomorrow
+            <h2 className="text-h2 font-semibold text-storm">
+              Estate releases, crypto keys, and provenance orchestrated together.
             </h2>
-            <p className="max-w-[65ch] text-lead text-thunder">
-              Digital Legacy uses Torvus policy orchestration to manage executors, staged
-              releases, and provenance so sensitive archives only surface when preset
-              conditions are satisfied.
+            <p className="max-w-[65ch] text-body text-thunder">
+              Whether you are preparing a family archive or safeguarding investigative
+              material, Torvus keeps your intent encrypted until policy conditions are
+              satisfied, then guides executors through each approval.
             </p>
             <div className="flex flex-wrap items-center gap-3">
-              <PrimarySubtleLink href="/digital-legacy">
-                Explore Digital Legacy
-              </PrimarySubtleLink>
               <Link
-                href="/use-cases"
+                href="/pricing"
                 className={buttonClasses({
-                  variant: "tertiary",
+                  variant: "secondary",
                   size: "sm",
-                  className: "border-lapis/45 text-lapis",
+                  className: "border-lagoon/45 text-lagoon",
                 })}
               >
-                View use cases
+                Compare plans
+              </Link>
+              <Link
+                href="/digital-legacy"
+                className="inline-flex items-center gap-2 text-[0.95rem] font-semibold text-lapis hover:underline"
+              >
+                Learn about Digital Legacy
+                <span aria-hidden="true">→</span>
               </Link>
             </div>
-          </div>
-          <div className="grid gap-4 text-[0.95rem] text-thunder">
-            {[
-              "Liveness checks and duress signals tuned for estate workflows",
-              "Executor collaboration without exposing plaintext",
-              "Laplace-blue theming aligns with Digital Legacy identity",
-            ].map((item) => (
-              <IconChip key={item} tone="lapis" icon="check" className="justify-start">
-                {item}
+            <div className="mt-6 grid gap-2 text-[0.95rem] text-thunder">
+              <IconChip tone="lagoon" icon="users">
+                Executors complete KYC and maintain ongoing check-ins.
               </IconChip>
-            ))}
+              <IconChip tone="lapis" icon="check">
+                Recipient provenance certificates confirm every disclosure.
+              </IconChip>
+              <IconChip tone="cranberry" icon="shield">
+                Duress pause halts releases instantly without alerting observers.
+              </IconChip>
+            </div>
           </div>
-        </div>
-      </section>
-
-      <section className="relative overflow-hidden pt-[calc(var(--section-pt)*0.8)] pb-[calc(var(--section-pb)*0.8)]">
-        <div
-          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-mist/40 shadow-[0_1px_0_rgba(0,0,0,0.04)_inset]"
-          aria-hidden="true"
-        />
-        <div className="container">
-          <p className="text-[0.95rem] font-semibold uppercase tracking-[0.24em] text-cranberry">
-            Trusted partners
-          </p>
-          <p className="text-gradient-hero text-h3 font-semibold text-storm">
-            Working with journalists, NGOs, and professionals protecting critical
-            missions.
-          </p>
-          <div className="mt-6 grid gap-6 text-[0.95rem] text-thunder md:grid-cols-2">
-            <Card className="hover-card pressable border border-white/60 bg-white/90 p-6">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-h4 font-semibold text-storm">
-                  Field reporting teams
-                </CardTitle>
-              </CardHeader>
-              <CardDescription>
-                Coordinating disclosures across bureaus and stringers requires cooperative
-                controls. Torvus keeps sensitive details sealed until checks complete,
-                while provenance proves who saw what, when.
-              </CardDescription>
-            </Card>
-            <Card className="hover-card pressable border border-white/60 bg-white/90 p-6">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-h4 font-semibold text-storm">
-                  Humanitarian operators
-                </CardTitle>
-              </CardHeader>
-              <CardDescription>
-                Mission-critical context, safehouse logistics, and comms plans sit behind
-                duress-aware policies. Release windows, executor quorums, and silent
-                pauses keep teams safe even under pressure.
-              </CardDescription>
-            </Card>
-            <Card className="hover-card pressable border border-white/60 bg-white/90 p-6">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-h4 font-semibold text-storm">
-                  Strategic security teams
-                </CardTitle>
-              </CardHeader>
-              <CardDescription>
-                Blend zero-knowledge encryption with estate workflows, approvals, and
-                auditability. Torvus lets security operations, legal, and leadership share
-                sensitive intel without dead drops or uncontrolled hand-offs.
-              </CardDescription>
-            </Card>
-            <Card className="hover-card pressable border border-white/60 bg-white/90 p-6">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-h4 font-semibold text-storm">
-                  Estate and fiduciary partners
-                </CardTitle>
-              </CardHeader>
-              <CardDescription>
-                Executors receive checklists, provenance, and automated attestation logs.
-                Sensitive artefacts stay encrypted until predicates complete—ensuring
-                compliance without sacrificing privacy.
-              </CardDescription>
-            </Card>
+          <div className="relative overflow-hidden rounded-3xl border border-storm/12 bg-white/95 p-8 shadow-soft-1">
+            <div
+              className="pointer-events-none absolute inset-0 bg-grad-panel opacity-60"
+              aria-hidden="true"
+            />
+            <div className="relative space-y-5">
+              <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
+                Release policy snapshot
+              </p>
+              <h3 className="text-h3 font-semibold text-storm">
+                Death verification <span className="text-lagoon">meets</span> executor
+                quorum.
+              </h3>
+              <ul className="space-y-3 text-[0.96rem] text-thunder">
+                <li className="flex items-start gap-3">
+                  <span
+                    className="mt-[0.35rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lapis"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    Minimum 14-day inactivity, probate confirmation, plus two executor
+                    attestations.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="mt-[0.35rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    Optional duress pause that alerts a trusted contact and suspends
+                    timers.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="mt-[0.35rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-cranberry"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    Crypto key handover requires threshold signatures before shards
+                    decrypt.
+                  </span>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </section>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,11 +9,13 @@ const staticPaths: SitePath[] = [
   "/features",
   "/security",
   "/digital-legacy",
+  "/pricing",
   "/use-cases",
   "/waitlist",
   "/faq",
   "/contact",
   "/status",
+  "/trust",
   "/legal/privacy",
   "/legal/terms",
 ];

--- a/components/analytics-event.tsx
+++ b/components/analytics-event.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { trackEvent, trackPageView } from "@/lib/analytics";
+
+type AnalyticsEventProps = {
+  event: string;
+  properties?: Record<string, unknown>;
+  pagePath?: string;
+};
+
+export function AnalyticsEvent({ event, properties, pagePath }: AnalyticsEventProps) {
+  useEffect(() => {
+    trackEvent(event, properties);
+    if (pagePath) {
+      trackPageView(pagePath);
+    }
+  }, [event, pagePath, properties]);
+
+  return null;
+}

--- a/components/analytics-scripts.tsx
+++ b/components/analytics-scripts.tsx
@@ -1,0 +1,55 @@
+import { headers } from "next/headers";
+import Script from "next/script";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+export function AnalyticsScripts() {
+  const nonce = headers().get("x-torvus-csp-nonce") ?? undefined;
+
+  return (
+    <>
+      {GA_ID ? (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            strategy="afterInteractive"
+            nonce={nonce}
+          />
+          <Script id="ga-init" strategy="afterInteractive" nonce={nonce}>
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${GA_ID}', { anonymize_ip: true });
+            `}
+          </Script>
+        </>
+      ) : null}
+      {POSTHOG_KEY ? (
+        <Script id="posthog-init" strategy="afterInteractive" nonce={nonce}>
+          {`
+            (function(p,o,s,t,h){
+              if(!p.posthog){
+                p.posthog={_i:[],init:function(i,c,r){function l(o){return function(){p.posthog._i.push([o,arguments])}}var _=p.posthog;
+                _.people={set:l('people.set')};_.capture=l('capture');_.identify=l('identify');_.alias=l('alias');_.group=l('group');
+                _.set=l('set');_.set_once=l('set_once');_.opt_in_capturing=l('opt_in_capturing');_.opt_out_capturing=l('opt_out_capturing');
+                _.has_opted_in_capturing=function(){return false};_.has_opted_out_capturing=function(){return false};
+                _.onFeatureFlags=l('onFeatureFlags');_.reloadFeatureFlags=l('reloadFeatureFlags');
+                _.isFeatureEnabled=function(){return false};_.reset=l('reset');_.pageview=l('pageview');
+                _.init(i,c,r);
+                if(!document.getElementById('posthog-js')){
+                  var d=o.createElement('script');d.type='text/javascript';d.id='posthog-js';d.async=true;d.src=t;
+                  var s=o.getElementsByTagName('script')[0];s.parentNode.insertBefore(d,s);
+                }
+              }
+            }})(window,document,'script','${POSTHOG_HOST}/static/array.js');
+            window.posthog?.init('${POSTHOG_KEY}', { api_host: '${POSTHOG_HOST}', capture_pageview: false });
+            window.posthog?.capture('pageview');
+          `}
+        </Script>
+      ) : null}
+    </>
+  );
+}

--- a/components/device-mock.tsx
+++ b/components/device-mock.tsx
@@ -1,0 +1,18 @@
+import { PhoneMock } from "@/components/phone-mock";
+
+export function DeviceMock() {
+  return (
+    <div className="relative flex justify-center">
+      <div
+        className="absolute -inset-6 rounded-[32px] bg-gradient-to-br from-pastel-cranberry/40 via-white/60 to-pastel-lapis/40 blur-[100px]"
+        aria-hidden="true"
+      />
+      <PhoneMock
+        scheme="light"
+        accent="lapis"
+        narrow={false}
+        ariaLabel="Torvus Digital Legacy mobile preview"
+      />
+    </div>
+  );
+}

--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -1,0 +1,51 @@
+const faqs = [
+  {
+    question: "How will billing work when Torvus Digital Legacy launches?",
+    answer:
+      "Individual accounts start with complimentary storage for core Digital Legacy items. Professional and Enterprise tiers include invoicing options and volume-based pricing when team features unlock.",
+  },
+  {
+    question: "What security assurances do you provide?",
+    answer:
+      "All vault data is encrypted client-side with keys stored separately. Roadmapped hardware-backed KMS and customer-managed keys add further assurance. Review our Security page for detailed controls and attestations.",
+  },
+  {
+    question: "Where is data located?",
+    answer:
+      "Initial regions are Australia and the EU with roadmap support for additional residency zones based on demand. Enterprise deployments can discuss bespoke hosting arrangements.",
+  },
+  {
+    question: "What uptime SLA can we expect?",
+    answer:
+      "During preview we operate with target 99.5% availability and transparent incident reporting. Enterprise contracts include custom SLAs, runbooks, and contact routes.",
+  },
+];
+
+export function FAQ() {
+  return (
+    <section className="pt-[calc(var(--section-pt)*0.7)] pb-[calc(var(--section-pb)*0.7)]">
+      <div className="container space-y-8">
+        <h2 className="text-h2 font-semibold text-storm">Pricing & rollout questions</h2>
+        <div className="space-y-4">
+          {faqs.map((faq) => (
+            <details
+              key={faq.question}
+              className="group rounded-2xl border border-storm/12 bg-white/95 p-5 shadow-soft-1"
+            >
+              <summary className="flex cursor-pointer items-center justify-between gap-4 text-left text-[1.05rem] font-semibold text-storm">
+                {faq.question}
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-storm/15 text-lagoon transition group-open:rotate-45"
+                >
+                  +
+                </span>
+              </summary>
+              <p className="mt-3 text-[0.96rem] text-thunder">{faq.answer}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,18 +1,22 @@
 import Link from "next/link";
 
 import { PrimarySubtleLink } from "@/components/ui/button";
-import { primaryNavigation, secondaryNavigation } from "@/lib/navigation";
+import { companyNavigation, productNavigation, trustNavigation } from "@/lib/navigation";
 
-const productSet = new Set(["/product", "/features", "/digital-legacy", "/use-cases"]);
-const trustSet = new Set(["/security", "/faq", "/contact"]);
+const productLinks = [
+  { href: "/product", label: "Platform overview" },
+  { href: "/digital-legacy", label: "Digital Legacy" },
+  { href: "/pricing", label: "Pricing" },
+  ...productNavigation.map(({ href, label }) => ({ href, label })),
+];
 
-const productLinks = primaryNavigation
-  .filter((link) => productSet.has(link.href))
-  .map(({ href, label }) => ({ href, label }));
-const trustLinks = primaryNavigation
-  .filter((link) => trustSet.has(link.href))
-  .map(({ href, label }) => ({ href, label }));
-const resources = secondaryNavigation.map(({ href, label }) => ({ href, label }));
+const trustLinks = [{ href: "/trust", label: "Trust Center" }, ...trustNavigation];
+
+const resourcesLinks = [
+  { href: "/legal/privacy", label: "Privacy" },
+  { href: "/legal/terms", label: "Terms" },
+  ...companyNavigation.filter((link) => link.href === "/contact"),
+];
 
 const currentYear = new Date().getFullYear();
 
@@ -22,7 +26,7 @@ export default function Footer() {
       <div className="mx-auto w-[min(1100px,92vw)] px-6 py-14">
         <div className="grid gap-10 md:grid-cols-12">
           <div className="space-y-6 md:col-span-5">
-            <div className="inline-flex items-center gap-2 font-semibold text-[#0B1220]">
+            <div className="inline-flex items-center gap-2 font-semibold text-storm">
               <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 1.5 22.5 12 12 22.5 1.5 12Z" fill="#D61F69" />
               </svg>
@@ -30,42 +34,52 @@ export default function Footer() {
                 Torvus <span className="font-normal">Security</span>
               </span>
             </div>
-            <p className="max-w-[42ch] text-[15px] leading-6 text-[#1F2937]">
+            <p className="max-w-[42ch] text-[15px] leading-6 text-thunder">
               Safeguard disclosures with policy-based release, duress controls, and
               independently verifiable provenance.
             </p>
-            <div className="space-y-3 rounded-lg border border-black/10 p-4">
-              <div className="text-[12px] font-semibold tracking-[0.18em] text-[#1F2937]/80">
+            <div className="space-y-3 rounded-2xl border border-black/10 p-4 shadow-soft-1">
+              <div className="text-[12px] font-semibold tracking-[0.18em] text-thunder/70">
                 STAY INFORMED
               </div>
-              <p className="text-[15px] leading-6 text-[#1F2937]">
-                Sign up for product updates, security notes, and private preview cohorts.
+              <p className="text-[15px] leading-6 text-thunder">
+                Join the waitlist to hear about Digital Legacy previews, security updates,
+                and rollout windows.
               </p>
               <PrimarySubtleLink href="/waitlist" className="mt-1 w-full sm:w-auto">
-                Sign up for updates
+                Join the waitlist
               </PrimarySubtleLink>
             </div>
           </div>
 
-          <nav className="grid grid-cols-2 gap-8 text-[15px] md:col-span-7 md:grid-cols-3">
-            <FooterLinks title="PRODUCT" links={productLinks} />
+          <nav
+            className="grid grid-cols-2 gap-8 text-[15px] md:col-span-7 md:grid-cols-3"
+            aria-label="Footer"
+          >
+            <FooterLinks title="PRODUCTS" links={productLinks} />
             <FooterLinks title="TRUST" links={trustLinks} />
-            <FooterLinks title="RESOURCES" links={resources} />
+            <FooterLinks title="RESOURCES" links={resourcesLinks} />
           </nav>
         </div>
 
-        <div className="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-black/5 pt-6 text-[14px] text-[#1F2937]/80">
-          <div>© {currentYear} Torvus Security.</div>
+        <div className="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-black/5 pt-6 text-[14px] text-thunder/80">
+          <div>© {currentYear} Torvus Security. All rights reserved.</div>
           <div className="flex flex-wrap items-center gap-5">
             <Link href="/security" className="hover:underline">
-              Security posture
+              Security
+            </Link>
+            <Link href="/trust" className="hover:underline">
+              Trust Center
             </Link>
             <Link href="/status" className="hover:underline">
               Status
             </Link>
-            <a href="mailto:hello@torvussecurity.com" className="hover:underline">
-              hello@torvussecurity.com
-            </a>
+            <Link href="/legal/privacy" className="hover:underline">
+              Privacy
+            </Link>
+            <Link href="/legal/terms" className="hover:underline">
+              Terms
+            </Link>
           </div>
         </div>
       </div>
@@ -81,7 +95,7 @@ type FooterLinksProps = {
 function FooterLinks({ title, links }: FooterLinksProps) {
   return (
     <div>
-      <div className="text-[12px] font-semibold tracking-[0.18em] text-[#1F2937]/80">
+      <div className="text-[12px] font-semibold tracking-[0.18em] text-thunder/70">
         {title}
       </div>
       <ul className="mt-3 space-y-2">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,18 +2,90 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
 
 import BrandLogo from "@/components/brand";
-import { primaryNavigation } from "@/lib/navigation";
+import {
+  primaryNavigation,
+  productNavigation,
+  type NavigationLink,
+} from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 const CTA = {
   href: "/waitlist",
-  label: "Sign up for updates",
+  label: "Join the waitlist",
+};
+
+type ProductMenuState = {
+  open: boolean;
+  focusIndex: number;
 };
 
 export default function Header() {
   const pathname = usePathname();
+  const [menu, setMenu] = useState<ProductMenuState>({ open: false, focusIndex: 0 });
+  const [mobileProductsOpen, setMobileProductsOpen] = useState(false);
+
+  const desktopButtonRef = useRef<HTMLButtonElement | null>(null);
+  const mobileButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (!menu.open) return;
+      if (menuRef.current?.contains(event.target as Node)) return;
+      if (desktopButtonRef.current?.contains(event.target as Node)) return;
+      setMenu({ open: false, focusIndex: 0 });
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (!menu.open) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setMenu({ open: false, focusIndex: 0 });
+        desktopButtonRef.current?.focus();
+      } else if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setMenu((prev) => {
+          const nextIndex = (prev.focusIndex + 1) % productNavigation.length;
+          itemRefs.current[nextIndex]?.focus();
+          return { open: true, focusIndex: nextIndex };
+        });
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setMenu((prev) => {
+          const nextIndex =
+            (prev.focusIndex - 1 + productNavigation.length) % productNavigation.length;
+          itemRefs.current[nextIndex]?.focus();
+          return { open: true, focusIndex: nextIndex };
+        });
+      }
+    }
+
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [menu.open]);
+
+  useEffect(() => {
+    setMenu({ open: false, focusIndex: 0 });
+    setMobileProductsOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (menu.open) {
+      const index = menu.focusIndex ?? 0;
+      const target = itemRefs.current[index];
+      target?.focus();
+    } else {
+      itemRefs.current = [];
+    }
+  }, [menu.open, menu.focusIndex]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/65">
@@ -21,59 +93,236 @@ export default function Header() {
         <BrandLogo />
 
         <nav className="hidden items-center gap-6 lg:flex" aria-label="Primary">
-          {primaryNavigation.map((item) => {
-            const isActive = pathname === item.href;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "relative inline-flex items-center whitespace-nowrap border-b-2 border-transparent px-1 pb-1 text-[0.95rem] font-semibold transition-colors",
-                  isActive
-                    ? "border-cranberry text-cranberry"
-                    : "text-storm/70 hover:border-lagoon/60 hover:text-storm",
-                )}
-              >
-                {item.label}
-              </Link>
-            );
-          })}
+          <ProductMenu
+            menu={menu}
+            onToggle={() =>
+              setMenu((prev) => ({
+                open: !prev.open,
+                focusIndex: prev.open ? prev.focusIndex : 0,
+              }))
+            }
+            onClose={() => setMenu({ open: false, focusIndex: 0 })}
+            buttonRef={desktopButtonRef}
+            menuRef={menuRef}
+            itemRefs={itemRefs}
+            pathname={pathname}
+          />
+          {primaryNavigation.map((item) => (
+            <NavLink key={item.href} item={item} pathname={pathname} />
+          ))}
         </nav>
 
         <Link
           href={CTA.href}
-          className="inline-flex items-center justify-center rounded-full border border-cranberry/30 px-4 py-2 text-[0.95rem] font-semibold text-cranberry transition hover:bg-pastel-cranberry/60"
+          className="inline-flex items-center justify-center rounded-full border border-cranberry/30 bg-white/80 px-4 py-2 text-[0.95rem] font-semibold text-cranberry shadow-sm transition hover:border-cranberry/60 hover:text-cranberry/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cranberry/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
         >
           {CTA.label}
         </Link>
       </div>
 
       <nav
-        className="lg:hidden border-t border-black/5 bg-white/90 py-3"
+        className="border-t border-black/5 bg-white/90 py-3 lg:hidden"
         aria-label="Primary"
       >
-        <div className="container mx-auto flex gap-3 overflow-x-auto px-5">
-          {primaryNavigation.map((item) => {
-            const isActive = pathname === item.href;
-            return (
+        <div className="container mx-auto flex items-center gap-3 overflow-x-auto px-5">
+          <button
+            ref={mobileButtonRef}
+            type="button"
+            aria-haspopup="true"
+            aria-expanded={mobileProductsOpen}
+            aria-controls="mobile-products"
+            className="inline-flex items-center whitespace-nowrap rounded-full border border-storm/15 bg-white px-3 py-1.5 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
+            onClick={() => setMobileProductsOpen((prev) => !prev)}
+          >
+            Products
+            <span className="ml-2 inline-flex h-4 w-4 items-center justify-center">
+              <svg
+                aria-hidden="true"
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  mobileProductsOpen ? "rotate-180" : "rotate-0",
+                )}
+                viewBox="0 0 20 20"
+                fill="none"
+              >
+                <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
+              </svg>
+            </span>
+          </button>
+          {primaryNavigation.map((item) => (
+            <LinkChip key={item.href} item={item} pathname={pathname} />
+          ))}
+        </div>
+        {mobileProductsOpen ? (
+          <div
+            id="mobile-products"
+            className="container mx-auto mt-3 flex flex-wrap gap-3 px-5"
+          >
+            {productNavigation.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                aria-current={isActive ? "page" : undefined}
-                className={cn(
-                  "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1.5 text-[0.9rem] font-semibold transition",
-                  isActive
-                    ? "border-cranberry bg-pastel-cranberry/40 text-cranberry"
-                    : "border-storm/10 bg-white text-storm/70 hover:border-lagoon/40 hover:text-storm",
-                )}
+                className="inline-flex flex-1 min-w-[140px] items-center justify-center whitespace-nowrap rounded-xl border border-storm/10 bg-white px-3 py-2 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
               >
                 {item.label}
               </Link>
-            );
-          })}
-        </div>
+            ))}
+          </div>
+        ) : null}
       </nav>
     </header>
   );
+}
+
+type NavLinkProps = {
+  item: NavigationLink;
+  pathname: string;
+};
+
+function NavLink({ item, pathname }: NavLinkProps) {
+  const isActive = pathname === item.href;
+  return (
+    <Link
+      href={item.href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "relative inline-flex items-center whitespace-nowrap border-b-2 border-transparent px-1 pb-1 text-[0.95rem] font-semibold transition-colors",
+        isActive
+          ? "border-cranberry text-cranberry"
+          : "text-storm/70 hover:border-lagoon/60 hover:text-storm",
+      )}
+    >
+      {item.label}
+    </Link>
+  );
+}
+
+type ProductMenuProps = {
+  menu: ProductMenuState;
+  onToggle: () => void;
+  onClose: () => void;
+  buttonRef: MutableRefObject<HTMLButtonElement | null>;
+  menuRef: MutableRefObject<HTMLDivElement | null>;
+  itemRefs: MutableRefObject<(HTMLAnchorElement | null)[]>;
+  pathname: string;
+};
+
+function ProductMenu({
+  menu,
+  onToggle,
+  onClose,
+  buttonRef,
+  menuRef,
+  itemRefs,
+  pathname,
+}: ProductMenuProps) {
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-storm/15 bg-white/80 px-3 py-1.5 text-[0.95rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+        aria-haspopup="true"
+        aria-expanded={menu.open}
+        aria-controls="desktop-product-menu"
+        onClick={() => onToggle()}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" && !menu.open) {
+            event.preventDefault();
+            onToggle();
+          }
+        }}
+      >
+        Products
+        <svg
+          aria-hidden="true"
+          className={cn(
+            "h-4 w-4 transition-transform",
+            menu.open ? "rotate-180" : "rotate-0",
+          )}
+          viewBox="0 0 20 20"
+          fill="none"
+        >
+          <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+      {menu.open ? (
+        <div
+          ref={menuRef}
+          id="desktop-product-menu"
+          role="menu"
+          aria-label="Products"
+          className="absolute left-0 top-full z-50 mt-3 w-[320px] rounded-2xl border border-storm/10 bg-white p-3 shadow-[0_22px_60px_rgba(11,18,32,0.14)]"
+        >
+          <ul className="space-y-1">
+            {productNavigation.map((item, index) => {
+              const itemPath = getPathname(item.href);
+              const isActive = pathname === itemPath;
+              return (
+                <li key={item.href}>
+                  <Link
+                    ref={(node) => {
+                      itemRefs.current[index] = node;
+                    }}
+                    href={item.href}
+                    role="menuitem"
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "flex flex-col gap-1 rounded-xl px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                      isActive
+                        ? "bg-pastel-lagoon/60 text-storm"
+                        : "hover:bg-mist/60 text-storm/80 hover:text-storm",
+                    )}
+                    onClick={() => {
+                      onClose();
+                    }}
+                  >
+                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
+                    {item.description ? (
+                      <span className="text-[0.8rem] text-thunder/75">
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type LinkChipProps = {
+  item: NavigationLink;
+  pathname: string;
+};
+
+function LinkChip({ item, pathname }: LinkChipProps) {
+  const itemPath = getPathname(item.href);
+  const isActive = pathname === itemPath;
+  return (
+    <Link
+      href={item.href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1.5 text-[0.9rem] font-semibold transition",
+        isActive
+          ? "border-cranberry bg-pastel-cranberry/40 text-cranberry"
+          : "border-storm/10 bg-white text-storm/70 hover:border-lagoon/40 hover:text-storm",
+      )}
+    >
+      {item.label}
+    </Link>
+  );
+}
+
+function getPathname(href: string) {
+  try {
+    const url = new URL(href, "https://torvussecurity.com");
+    return url.pathname;
+  } catch {
+    return href;
+  }
 }

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+
+import { DeviceMock } from "@/components/device-mock";
+import { IconChip } from "@/components/icon-chip";
+import { PrimarySubtleLink, buttonClasses } from "@/components/ui/button";
+
+const highlights = [
+  {
+    icon: "key" as const,
+    tone: "lapis" as const,
+    copy: "Asset inventory with intent capture for every vault item",
+  },
+  {
+    icon: "users" as const,
+    tone: "lagoon" as const,
+    copy: "Executor identities verified with policy-backed approvals",
+  },
+  {
+    icon: "timer" as const,
+    tone: "cranberry" as const,
+    copy: "Death verification predicates and grace periods you control",
+  },
+  {
+    icon: "shield" as const,
+    tone: "lapis" as const,
+    copy: "Duress pause and audit provenance baked into every release",
+  },
+];
+
+export function Hero() {
+  return (
+    <section className="relative overflow-hidden border-b border-storm/10 bg-gradient-to-br from-white via-pastel-lapis/35 to-white pt-[var(--section-pt)] pb-[var(--section-pb)]">
+      <div
+        className="pointer-events-none absolute -left-24 top-16 h-72 w-72 rounded-full bg-pastel-cranberry/60 blur-[160px]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute right-[-10%] top-10 h-80 w-80 rounded-full bg-pastel-lapis/60 blur-[180px]"
+        aria-hidden="true"
+      />
+
+      <div className="container relative grid gap-16 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)] lg:items-center">
+        <div className="space-y-7 rounded-2xl border border-white/60 bg-white/90 p-8 shadow-[0_22px_60px_rgba(11,18,32,0.12)] backdrop-blur-sm">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+            Digital Legacy Kit
+          </p>
+          <h1 className="text-display font-semibold text-storm">
+            Preserve your intent and release it only when it truly matters.
+          </h1>
+          <p className="max-w-[60ch] text-lead text-thunder">
+            Torvus Digital Legacy seals assets, instructions, and crypto secrets behind
+            policy-orchestrated releases so executors only receive what you intend—after
+            verification and with provenance.
+          </p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+              Join the waitlist
+            </PrimarySubtleLink>
+            <Link
+              href="/digital-legacy"
+              className={buttonClasses({
+                variant: "tertiary",
+                size: "sm",
+                className: "border-lapis/45 text-lapis",
+              })}
+            >
+              Explore Digital Legacy
+            </Link>
+          </div>
+          <p className="max-w-[60ch] text-[0.94rem] text-thunder">
+            Zero-knowledge encryption, duress controls, and executors with verified
+            identities. No plaintext ever leaves your vault without the conditions you
+            set.
+          </p>
+          <div className="mt-6 grid gap-2 text-[0.92rem]">
+            {highlights.map((item) => (
+              <IconChip key={item.copy} tone={item.tone} icon={item.icon}>
+                {item.copy}
+              </IconChip>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-8">
+          <DeviceMock />
+          <div className="w-full max-w-[340px] space-y-4 rounded-2xl border border-storm/10 bg-white/95 p-6 shadow-soft-1">
+            <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
+              Estate orchestrator
+            </p>
+            <h2 className="text-h4 font-semibold text-storm">
+              Executors receive policy-backed checklists with provenance.
+            </h2>
+            <ul className="space-y-2 text-[0.95rem] text-thunder">
+              <li className="flex gap-3">
+                <span
+                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lapis"
+                  aria-hidden="true"
+                />
+                <span>
+                  Per-recipient bundles with redaction controls before anything unlocks.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                  aria-hidden="true"
+                />
+                <span>
+                  Verified executors complete step-by-step check-ins monitored by Torvus.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-cranberry"
+                  aria-hidden="true"
+                />
+                <span>All actions produce tamper-evident provenance certificates.</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/pricing-tiers.tsx
+++ b/components/pricing-tiers.tsx
@@ -1,0 +1,150 @@
+import Link from "next/link";
+
+import { PrimarySubtleLink, buttonClasses } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { trackEvent } from "@/lib/analytics";
+
+type Tier = {
+  id: string;
+  name: string;
+  price: string;
+  summary: string;
+  features: string[];
+  cta: { label: string; href: string; variant?: "primary" | "secondary" | "link" };
+};
+
+const tiers: Tier[] = [
+  {
+    id: "individual",
+    name: "Torvus Individual",
+    price: "Coming soon",
+    summary: "Core vault plus Digital Legacy essentials for personal archives.",
+    features: [
+      "Guided inventory for passwords, documents, and crypto notes.",
+      "Digital Legacy policy presets with inactivity timers.",
+      "Two executors and five recipients with verification.",
+    ],
+    cta: { label: "Join the waitlist", href: "/waitlist", variant: "primary" },
+  },
+  {
+    id: "professional",
+    name: "Torvus Professional",
+    price: "Team pricing",
+    summary:
+      "Advanced policies, KYC for executors, and enhanced audit export for journalists, NGOs, and estate planners.",
+    features: [
+      "Multi-signal release predicates with manual review lanes.",
+      "Executor KYC, redaction-ready dry runs, and recipient portal.",
+      "Extended audit exports with integration hooks and API webhooks.",
+    ],
+    cta: { label: "Request access", href: "/waitlist", variant: "secondary" },
+  },
+  {
+    id: "enterprise",
+    name: "Torvus Enterprise",
+    price: "Custom",
+    summary:
+      "Enterprise agreements with SSO/SAML, dedicated support, DPA/BAA options, and bespoke estate workflows.",
+    features: [
+      "Custom estate-mode orchestration with policy simulations.",
+      "Dedicated success team, response SLAs, and security reviews.",
+      "SSO/SAML, SCIM, and regional data residency roadmaps.",
+    ],
+    cta: {
+      label: "Contact sales",
+      href: "mailto:security@torvussecurity.com",
+      variant: "link",
+    },
+  },
+];
+
+export function PricingTiers() {
+  return (
+    <section className="pt-[calc(var(--section-pt)*0.85)] pb-[calc(var(--section-pb)*0.85)]">
+      <div className="container space-y-10">
+        <div className="space-y-3 text-center">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lagoon">
+            Pricing
+          </p>
+          <h2 className="text-h2 font-semibold text-storm">
+            Choose the Torvus plan that fits how you work.
+          </h2>
+          <p className="mx-auto max-w-prose text-body text-thunder">
+            Start with the Individual toolkit, scale to Professional for advanced
+            workflows, or partner with us on Enterprise for custom orchestration.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {tiers.map((tier) => (
+            <Card key={tier.id} id={tier.id} className="h-full border-storm/12">
+              <CardHeader>
+                <CardTitle>{tier.name}</CardTitle>
+                <CardDescription>{tier.summary}</CardDescription>
+                <p className="text-[1rem] font-semibold text-lapis">{tier.price}</p>
+              </CardHeader>
+              <ul className="space-y-2 text-[0.95rem] text-thunder">
+                {tier.features.map((feature) => (
+                  <li key={feature} className="flex gap-3">
+                    <span
+                      className="mt-[0.35rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                      aria-hidden="true"
+                    />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-6">{renderTierCta(tier)}</div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function renderTierCta(tier: Tier) {
+  const handleClick = () =>
+    trackEvent("pricing_cta_click", { tier: tier.id, label: tier.cta.label });
+
+  if (tier.cta.variant === "link") {
+    return (
+      <Link
+        href={tier.cta.href}
+        className="inline-flex items-center gap-2 text-[0.95rem] font-semibold text-lapis hover:underline"
+        data-pricing-cta={tier.id}
+        onClick={handleClick}
+      >
+        {tier.cta.label}
+        <span aria-hidden="true">→</span>
+      </Link>
+    );
+  }
+
+  if (tier.cta.variant === "secondary") {
+    return (
+      <Link
+        href={tier.cta.href}
+        className={buttonClasses({
+          variant: "secondary",
+          size: "sm",
+          className: "border-lapis/45 text-lapis",
+        })}
+        data-pricing-cta={tier.id}
+        onClick={handleClick}
+      >
+        {tier.cta.label}
+      </Link>
+    );
+  }
+
+  return (
+    <PrimarySubtleLink
+      href={tier.cta.href}
+      data-pricing-cta={tier.id}
+      className="w-full"
+      onClick={handleClick}
+    >
+      {tier.cta.label}
+    </PrimarySubtleLink>
+  );
+}

--- a/components/tiles.tsx
+++ b/components/tiles.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const howItWorks = [
+  {
+    title: "Inventory & intent capture",
+    description:
+      "Catalogue passwords, documents, and media while tagging the people who should receive them and the context they need.",
+    bullets: [
+      "Guided templates for accounts, crypto wallets, and instructions.",
+      "Intent notes stay encrypted until your policy grants access.",
+    ],
+  },
+  {
+    title: "Legacy agents with KYC",
+    description:
+      "Appoint executors and professional custodians. Torvus verifies their identities before they can act on your estate.",
+    bullets: [
+      "Executor onboarding with identity checks and optional MFA.",
+      "Dry-run simulations and redaction previews before launch.",
+    ],
+  },
+  {
+    title: "Death verification predicate",
+    description:
+      "Blend inactivity windows with human attestations. Manual probate review today, integrations with registries tomorrow.",
+    bullets: [
+      "Multiple signals must agree before estate mode activates.",
+      "Grace periods and escalation paths avoid premature release.",
+    ],
+  },
+  {
+    title: "Estate mode orchestrator",
+    description:
+      "Once verified, Torvus stages releases per recipient with transparent provenance, approvals, and audit certificates.",
+    bullets: [
+      "Checklist workflows tuned for executors and legal teams.",
+      "Per-recipient bundles with delivery windows you control.",
+    ],
+  },
+  {
+    title: "Optional crypto key handover",
+    description:
+      "Use Shamir-style threshold splits so no single party ever holds your entire key. Executors collaborate to reconstruct it.",
+    bullets: [
+      "Configurable thresholds and recovery guardians.",
+      "Hardware wallet attestations recorded for every reveal.",
+    ],
+  },
+];
+
+const audiences = [
+  {
+    title: "Individuals",
+    description:
+      "Protect family access to critical records without surrendering privacy while you’re alive.",
+    link: { href: "/pricing#individual", label: "See Individual tier" },
+  },
+  {
+    title: "Journalists & NGOs",
+    description:
+      "Share source material, crisis plans, and escrowed evidence safely across borders.",
+    link: { href: "/digital-legacy#capabilities", label: "Explore capabilities" },
+  },
+  {
+    title: "Lawyers & estate planners",
+    description: "Deliver digital estate readiness to clients with auditable workflows.",
+    link: { href: "/pricing#professional", label: "Review Professional" },
+  },
+];
+
+export function HowItWorksTiles() {
+  return (
+    <section className="pt-[calc(var(--section-pt)*0.85)] pb-[calc(var(--section-pb)*0.85)]">
+      <div className="container space-y-12">
+        <div className="space-y-3 text-center">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lagoon">
+            How it works
+          </p>
+          <h2 className="text-h2 font-semibold text-storm">
+            Estate resilience without compromising operational security.
+          </h2>
+          <p className="mx-auto max-w-prose text-body text-thunder">
+            Each component keeps your digital legacy verifiable, revocable, and private.
+            Executors and recipients only see what they’re cleared to handle—and every
+            step is logged.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {howItWorks.map((item) => (
+            <Card key={item.title} className="h-full border-storm/12">
+              <CardHeader className="gap-3">
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+              <ul className="mt-1 space-y-2 text-[0.95rem] text-thunder">
+                {item.bullets.map((bullet) => (
+                  <li key={bullet} className="flex gap-3">
+                    <span
+                      className="mt-[0.45rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                      aria-hidden="true"
+                    />
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function AudienceTiles() {
+  return (
+    <section className="bg-gradient-to-br from-white via-mist/60 to-white py-[calc(var(--section-pt)*0.7)]">
+      <div className="container space-y-10">
+        <div className="space-y-2 text-center">
+          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+            Who it’s for
+          </p>
+          <h2 className="text-h2 font-semibold text-storm">
+            Built for the people who cannot afford missteps.
+          </h2>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {audiences.map((audience) => (
+            <Card key={audience.title} className="h-full border-storm/12">
+              <CardHeader>
+                <CardTitle>{audience.title}</CardTitle>
+                <CardDescription>{audience.description}</CardDescription>
+              </CardHeader>
+              <Link
+                href={audience.link.href}
+                className="inline-flex items-center gap-2 text-[0.95rem] font-semibold text-lapis hover:underline"
+              >
+                {audience.link.label}
+                <span aria-hidden="true">→</span>
+              </Link>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -36,7 +36,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 const sizeClasses: Record<ButtonSize, string> = {
   sm: "px-5 py-2 text-[0.98rem] md:px-6",
   md: "px-5 py-2.5 text-[1rem] md:px-6",
-  lg: "px-6 py-3 text-[1.04rem] md:px-7",
+  lg: "px-6 py-2.5 text-[1.02rem] md:px-7",
 };
 
 export function buttonClasses({

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,15 +1,15 @@
 # Analytics Stub
 
-Third-party analytics are intentionally omitted. The plan is to introduce a self-hosted or privacy-preserving module that can be toggled per environment.
+Analytics now use Google Analytics 4 and PostHog with minimal event capture. Scripts load with the middleware-provided nonce so CSP remains intact.
 
-Current state:
+Current events:
 
-- No tracking requests are sent from the marketing site.
-- Middleware provides a hook (`x-torvus-csp-nonce`) to safely inject future first-party scripts.
-- When analytics are required we will prefer self-hosted solutions (e.g., PostHog, Plausible) or bespoke measurement via server-side logging.
+- `dl_page_view` fires on the Digital Legacy page and mirrors a pageview call.
+- `pricing_cta_click` captures tier + CTA label from the pricing cards.
+- `waitlist_submit` triggers when the Fillout embed surfaces a thank-you state (message listener fallback).
 
-Open questions:
+Scripts honour the CSP `nonce` header (`x-torvus-csp-nonce`). Configure the following public environment variables when deploying:
 
-- Which Preview/Prod environments should receive metrics?
-- Do we want to store session data in Torvus infrastructure or a separate lake?
-- How does analytics reconcile with CSP and privacy commitments?
+- `NEXT_PUBLIC_GA_ID`
+- `NEXT_PUBLIC_POSTHOG_KEY`
+- `NEXT_PUBLIC_POSTHOG_HOST`

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,41 @@
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+    posthog?: {
+      capture: (event: string, properties?: Record<string, unknown>) => void;
+      identify?: (id: string, properties?: Record<string, unknown>) => void;
+      pageview?: () => void;
+    };
+  }
+}
+
+export function trackEvent(event: string, properties?: Record<string, unknown>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", event, properties ?? {});
+  }
+
+  if (window.posthog?.capture) {
+    window.posthog.capture(event, properties ?? {});
+  }
+}
+
+export function trackPageView(path: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", "page_view", { page_path: path });
+  }
+
+  if (window.posthog?.capture) {
+    window.posthog.capture("pageview", { path });
+  } else if (window.posthog?.pageview) {
+    window.posthog.pageview();
+  }
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,19 +1,40 @@
-type NavigationItem = {
+export type NavigationLink = {
   href: string;
   label: string;
-  description: string;
+  description?: string;
 };
 
-export const primaryNavigation: NavigationItem[] = [
+export const productNavigation: NavigationLink[] = [
+  {
+    href: "/pricing#individual",
+    label: "Torvus Individual",
+    description:
+      "Secure personal archives with Digital Legacy basics, inventory, and guided releases.",
+  },
+  {
+    href: "/pricing#professional",
+    label: "Torvus Professional",
+    description:
+      "Advanced policies, executor KYC, and provenance features for journalists and planners.",
+  },
+  {
+    href: "/pricing#enterprise-contact",
+    label: "Torvus Enterprise",
+    description:
+      "Custom estate orchestration, SSO, and support. Connect with the Torvus team to scope.",
+  },
+];
+
+export const primaryNavigation: NavigationLink[] = [
   {
     href: "/product",
     label: "Product",
     description: "Understand the Torvus vault, policy engine, and control center.",
   },
   {
-    href: "/security",
-    label: "Security",
-    description: "Hardening approach, attestations, and zero-knowledge guarantees.",
+    href: "/digital-legacy",
+    label: "Digital Legacy",
+    description: "Plan estate disclosures and contingencies with Torvus Digital Legacy.",
   },
   {
     href: "/features",
@@ -21,9 +42,14 @@ export const primaryNavigation: NavigationItem[] = [
     description: "Compose policies, duress modes, and recipient verification paths.",
   },
   {
-    href: "/digital-legacy",
-    label: "Digital Legacy",
-    description: "Plan estate disclosures and contingencies with Torvus Digital Legacy.",
+    href: "/pricing",
+    label: "Pricing",
+    description: "Compare Torvus Individual, Professional, and Enterprise tiers.",
+  },
+  {
+    href: "/security",
+    label: "Security",
+    description: "Hardening approach, attestations, and zero-knowledge guarantees.",
   },
   {
     href: "/use-cases",
@@ -42,7 +68,13 @@ export const primaryNavigation: NavigationItem[] = [
   },
 ];
 
-export const secondaryNavigation: NavigationItem[] = [
+// eslint-disable-next-line import/no-unused-modules
+export const trustNavigation: NavigationLink[] = [
+  {
+    href: "/security",
+    label: "Security",
+    description: "Hardening, encryption, and digital legacy assurances.",
+  },
   {
     href: "/status",
     label: "Status",
@@ -57,5 +89,19 @@ export const secondaryNavigation: NavigationItem[] = [
     href: "/legal/terms",
     label: "Terms",
     description: "Service terms, acceptable use, and contractual obligations.",
+  },
+];
+
+// eslint-disable-next-line import/no-unused-modules
+export const companyNavigation: NavigationLink[] = [
+  {
+    href: "/trust",
+    label: "Trust Center",
+    description: "Transparency hub with policies and external references.",
+  },
+  {
+    href: "/contact",
+    label: "Contact",
+    description: "Talk with Torvus about security reviews or tailored onboarding.",
   },
 ];

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Torvus Security",
   description:
-    "Policy-driven digital vaulting with encryption, provenance, and controlled release for teams that protect critical information.",
+    "Policy-driven digital vaulting with Digital Legacy orchestration, encryption, provenance, and controlled release for teams that protect critical information.",
   url: "https://www.torvussecurity.com",
   keywords: [
     "digital vault",
@@ -22,10 +22,12 @@ export type SitePath =
   | "/security"
   | "/features"
   | "/digital-legacy"
+  | "/pricing"
   | "/use-cases"
   | "/waitlist"
   | "/faq"
   | "/contact"
+  | "/trust"
   | "/legal/privacy"
   | "/legal/terms"
   | "/status";


### PR DESCRIPTION
## Summary
- Rebuilt the homepage hero and narrative for Torvus Digital Legacy, added device mock content, and introduced audience + capability tiles.
- Added dedicated /digital-legacy, /pricing, and /trust pages with tier cards, FAQ, contact pathways, and updated metadata including OG images.
- Implemented product navigation with dropdown, refreshed footer links, wired analytics (GA4/PostHog) events, and updated security/trust documentation plus sitemap.

## Testing
- `pnpm lint`
- `pnpm test`

## Checklist
- [x] Task 1 — Global IA & Navigation update with product dropdown and footer links
- [x] Task 2 — Brand tokens, typography, and CTA scale refinements
- [x] Task 3 — Homepage hero & Digital Legacy introduction
- [x] Task 4 — New /digital-legacy page
- [x] Task 5 — Pricing page & tier cards with FAQ
- [x] Task 6 — Security, Trust Center, Status copy refresh
- [x] Task 7 — Analytics & events (GA4 + PostHog)
- [x] Task 8 — CSP & Permissions-Policy adjustments for Fillout + analytics
- [x] Task 9 — SEO/OG assets & sitemap/robots updates
- [x] Task 10 — QA via lint/tests (Lighthouse tracked separately)


------
https://chatgpt.com/codex/tasks/task_b_68cd3e75590c832db70581217f58bd11