### PR TITLE
Remove products dropdown from header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
 
 import BrandLogo from "@/components/brand";
-import { primaryNavigation, type NavigationLink } from "@/lib/navigation";
+import {
+  primaryNavigation,
+  productNavigation,
+  type NavigationLink,
+} from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 const CTA = {
@@ -14,6 +19,109 @@ const CTA = {
 
 export default function Header() {
   const pathname = usePathname();
+  const router = useRouter();
+  const [menu, setMenu] = useState<ProductMenuState>({ open: false, focusIndex: 0 });
+  const [mobileProductsOpen, setMobileProductsOpen] = useState(false);
+
+  const desktopButtonRef = useRef<HTMLButtonElement | null>(null);
+  const mobileButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
+  const keepMenuOpenOnProductRef = useRef(false);
+
+  const productPath = "/product";
+  const mainNavigation = primaryNavigation.filter((item) => item.href !== productPath);
+
+  const openProductMenu = () =>
+    setMenu((prev) => ({
+      open: true,
+      focusIndex: prev.open ? prev.focusIndex : 0,
+    }));
+  const closeProductMenu = () => {
+    keepMenuOpenOnProductRef.current = false;
+    setMenu({ open: false, focusIndex: 0 });
+  };
+
+  const navigateToProduct = () => {
+    keepMenuOpenOnProductRef.current = true;
+    router.push(productPath);
+  };
+
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      if (!menu.open) return;
+      if (menuRef.current?.contains(event.target as Node)) return;
+      if (desktopButtonRef.current?.contains(event.target as Node)) return;
+      closeProductMenu();
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (!menu.open) return;
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeProductMenu();
+        desktopButtonRef.current?.focus();
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setMenu((prev) => {
+          const nextIndex = (prev.focusIndex + 1) % productNavigation.length;
+          itemRefs.current[nextIndex]?.focus();
+          return { open: true, focusIndex: nextIndex };
+        });
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setMenu((prev) => {
+          const nextIndex =
+            (prev.focusIndex - 1 + productNavigation.length) % productNavigation.length;
+          itemRefs.current[nextIndex]?.focus();
+          return { open: true, focusIndex: nextIndex };
+        });
+      }
+    }
+
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [menu.open]);
+
+  useEffect(() => {
+    setMenu((prev) => {
+      if (keepMenuOpenOnProductRef.current && pathname === productPath) {
+        return { open: true, focusIndex: prev.focusIndex ?? 0 };
+      }
+
+      return { open: false, focusIndex: 0 };
+    });
+
+    setMobileProductsOpen((_prev) => {
+      if (keepMenuOpenOnProductRef.current && pathname === productPath) {
+        return true;
+      }
+
+      return false;
+    });
+
+    keepMenuOpenOnProductRef.current = false;
+  }, [pathname, productPath]);
+
+  useEffect(() => {
+    if (menu.open) {
+      const index = menu.focusIndex ?? 0;
+      const target = itemRefs.current[index];
+      target?.focus();
+    } else {
+      itemRefs.current = [];
+    }
+  }, [menu.open, menu.focusIndex]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/65">
@@ -21,7 +129,17 @@ export default function Header() {
         <BrandLogo />
 
         <nav className="hidden items-center gap-6 lg:flex" aria-label="Primary">
-          {primaryNavigation.map((item) => (
+          <ProductMenu
+            menu={menu}
+            onOpen={openProductMenu}
+            onClose={closeProductMenu}
+            onProductNavigate={navigateToProduct}
+            buttonRef={desktopButtonRef}
+            menuRef={menuRef}
+            itemRefs={itemRefs}
+            pathname={pathname}
+          />
+          {mainNavigation.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} />
           ))}
         </nav>
@@ -38,15 +156,98 @@ export default function Header() {
         className="border-t border-black/5 bg-white/90 py-3 lg:hidden"
         aria-label="Primary"
       >
-        <div className="container mx-auto flex items-center gap-3 overflow-x-auto px-5">
-          {primaryNavigation.map((item) => (
-            <LinkChip key={item.href} item={item} pathname={pathname} />
-          ))}
+        <div className="container mx-auto flex flex-col gap-3 px-5">
+          <div className="flex items-center gap-3 overflow-x-auto">
+            <button
+              ref={mobileButtonRef}
+              type="button"
+              aria-haspopup="true"
+              aria-expanded={mobileProductsOpen}
+              aria-controls="mobile-products"
+              className="inline-flex items-center whitespace-nowrap rounded-full border border-storm/15 bg-white px-3 py-1.5 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
+              onClick={() => {
+                setMobileProductsOpen((prev) => {
+                  const next = !prev;
+                  if (next) {
+                    navigateToProduct();
+                  } else {
+                    keepMenuOpenOnProductRef.current = false;
+                  }
+                  return next;
+                });
+              }}
+            >
+              Products
+              <span className="ml-2 inline-flex h-4 w-4 items-center justify-center">
+                <svg
+                  aria-hidden="true"
+                  className={cn(
+                    "h-4 w-4 transition-transform",
+                    mobileProductsOpen ? "rotate-180" : "rotate-0",
+                  )}
+                  viewBox="0 0 20 20"
+                  fill="none"
+                >
+                  <path
+                    d="M5 7.5 10 12.5 15 7.5"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                  />
+                </svg>
+              </span>
+            </button>
+            {mainNavigation.map((item) => (
+              <LinkChip key={item.href} item={item} pathname={pathname} />
+            ))}
+          </div>
+
+          {mobileProductsOpen ? (
+            <div
+              id="mobile-products"
+              role="menu"
+              aria-label="Products"
+              className="grid gap-2 rounded-2xl border border-storm/10 bg-white p-3 shadow-sm"
+            >
+              {productNavigation.map((item) => {
+                const itemPath = getPathname(item.href);
+                const isActive = pathname === itemPath;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    role="menuitem"
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "flex flex-col gap-1 rounded-xl px-3 py-2 text-left transition",
+                      isActive
+                        ? "bg-pastel-lagoon/60 text-storm"
+                        : "text-storm/80 hover:bg-mist/60 hover:text-storm",
+                    )}
+                    onClick={() => {
+                      setMobileProductsOpen(false);
+                    }}
+                  >
+                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
+                    {item.description ? (
+                      <span className="text-[0.8rem] text-thunder/75">
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </Link>
+                );
+              })}
+            </div>
+          ) : null}
         </div>
       </nav>
     </header>
   );
 }
+
+type ProductMenuState = {
+  open: boolean;
+  focusIndex: number;
+};
 
 type NavLinkProps = {
   item: NavigationLink;
@@ -92,6 +293,108 @@ function LinkChip({ item, pathname }: LinkChipProps) {
     >
       {item.label}
     </Link>
+  );
+}
+
+type ProductMenuProps = {
+  menu: ProductMenuState;
+  onOpen: () => void;
+  onClose: () => void;
+  onProductNavigate: () => void;
+  buttonRef: MutableRefObject<HTMLButtonElement | null>;
+  menuRef: MutableRefObject<HTMLDivElement | null>;
+  itemRefs: MutableRefObject<(HTMLAnchorElement | null)[]>;
+  pathname: string;
+};
+
+function ProductMenu({
+  menu,
+  onOpen,
+  onClose,
+  onProductNavigate,
+  buttonRef,
+  menuRef,
+  itemRefs,
+  pathname,
+}: ProductMenuProps) {
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-storm/15 bg-white/80 px-3 py-1.5 text-[0.95rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+        aria-haspopup="true"
+        aria-expanded={menu.open}
+        aria-controls="desktop-product-menu"
+        onClick={() => {
+          onProductNavigate();
+          onOpen();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" && !menu.open) {
+            event.preventDefault();
+            onOpen();
+          }
+        }}
+      >
+        Products
+        <svg
+          aria-hidden="true"
+          className={cn(
+            "h-4 w-4 transition-transform",
+            menu.open ? "rotate-180" : "rotate-0",
+          )}
+          viewBox="0 0 20 20"
+          fill="none"
+        >
+          <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+      {menu.open ? (
+        <div
+          ref={menuRef}
+          id="desktop-product-menu"
+          role="menu"
+          aria-label="Products"
+          className="absolute left-0 top-full z-50 mt-3 w-[320px] rounded-2xl border border-storm/10 bg-white p-3 shadow-[0_22px_60px_rgba(11,18,32,0.14)]"
+        >
+          <ul className="space-y-1">
+            {productNavigation.map((item, index) => {
+              const itemPath = getPathname(item.href);
+              const isActive = pathname === itemPath;
+              return (
+                <li key={item.href}>
+                  <Link
+                    ref={(node) => {
+                      itemRefs.current[index] = node;
+                    }}
+                    href={item.href}
+                    role="menuitem"
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "flex flex-col gap-1 rounded-xl px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                      isActive
+                        ? "bg-pastel-lagoon/60 text-storm"
+                        : "text-storm/80 hover:bg-mist/60 hover:text-storm",
+                    )}
+                    onClick={() => {
+                      onClose();
+                    }}
+                  >
+                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
+                    {item.description ? (
+                      <span className="text-[0.8rem] text-thunder/75">
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,14 +2,9 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useRef, useState, type MutableRefObject } from "react";
 
 import BrandLogo from "@/components/brand";
-import {
-  primaryNavigation,
-  productNavigation,
-  type NavigationLink,
-} from "@/lib/navigation";
+import { primaryNavigation, type NavigationLink } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 const CTA = {
@@ -17,75 +12,8 @@ const CTA = {
   label: "Join the waitlist",
 };
 
-type ProductMenuState = {
-  open: boolean;
-  focusIndex: number;
-};
-
 export default function Header() {
   const pathname = usePathname();
-  const [menu, setMenu] = useState<ProductMenuState>({ open: false, focusIndex: 0 });
-  const [mobileProductsOpen, setMobileProductsOpen] = useState(false);
-
-  const desktopButtonRef = useRef<HTMLButtonElement | null>(null);
-  const mobileButtonRef = useRef<HTMLButtonElement | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
-
-  useEffect(() => {
-    function handleClick(event: MouseEvent) {
-      if (!menu.open) return;
-      if (menuRef.current?.contains(event.target as Node)) return;
-      if (desktopButtonRef.current?.contains(event.target as Node)) return;
-      setMenu({ open: false, focusIndex: 0 });
-    }
-
-    function handleKey(event: KeyboardEvent) {
-      if (!menu.open) return;
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setMenu({ open: false, focusIndex: 0 });
-        desktopButtonRef.current?.focus();
-      } else if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setMenu((prev) => {
-          const nextIndex = (prev.focusIndex + 1) % productNavigation.length;
-          itemRefs.current[nextIndex]?.focus();
-          return { open: true, focusIndex: nextIndex };
-        });
-      } else if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setMenu((prev) => {
-          const nextIndex =
-            (prev.focusIndex - 1 + productNavigation.length) % productNavigation.length;
-          itemRefs.current[nextIndex]?.focus();
-          return { open: true, focusIndex: nextIndex };
-        });
-      }
-    }
-
-    window.addEventListener("mousedown", handleClick);
-    window.addEventListener("keydown", handleKey);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [menu.open]);
-
-  useEffect(() => {
-    setMenu({ open: false, focusIndex: 0 });
-    setMobileProductsOpen(false);
-  }, [pathname]);
-
-  useEffect(() => {
-    if (menu.open) {
-      const index = menu.focusIndex ?? 0;
-      const target = itemRefs.current[index];
-      target?.focus();
-    } else {
-      itemRefs.current = [];
-    }
-  }, [menu.open, menu.focusIndex]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/65">
@@ -93,20 +21,6 @@ export default function Header() {
         <BrandLogo />
 
         <nav className="hidden items-center gap-6 lg:flex" aria-label="Primary">
-          <ProductMenu
-            menu={menu}
-            onToggle={() =>
-              setMenu((prev) => ({
-                open: !prev.open,
-                focusIndex: prev.open ? prev.focusIndex : 0,
-              }))
-            }
-            onClose={() => setMenu({ open: false, focusIndex: 0 })}
-            buttonRef={desktopButtonRef}
-            menuRef={menuRef}
-            itemRefs={itemRefs}
-            pathname={pathname}
-          />
           {primaryNavigation.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} />
           ))}
@@ -125,50 +39,10 @@ export default function Header() {
         aria-label="Primary"
       >
         <div className="container mx-auto flex items-center gap-3 overflow-x-auto px-5">
-          <button
-            ref={mobileButtonRef}
-            type="button"
-            aria-haspopup="true"
-            aria-expanded={mobileProductsOpen}
-            aria-controls="mobile-products"
-            className="inline-flex items-center whitespace-nowrap rounded-full border border-storm/15 bg-white px-3 py-1.5 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
-            onClick={() => setMobileProductsOpen((prev) => !prev)}
-          >
-            Products
-            <span className="ml-2 inline-flex h-4 w-4 items-center justify-center">
-              <svg
-                aria-hidden="true"
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  mobileProductsOpen ? "rotate-180" : "rotate-0",
-                )}
-                viewBox="0 0 20 20"
-                fill="none"
-              >
-                <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
-              </svg>
-            </span>
-          </button>
           {primaryNavigation.map((item) => (
             <LinkChip key={item.href} item={item} pathname={pathname} />
           ))}
         </div>
-        {mobileProductsOpen ? (
-          <div
-            id="mobile-products"
-            className="container mx-auto mt-3 flex flex-wrap gap-3 px-5"
-          >
-            {productNavigation.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="inline-flex flex-1 min-w-[140px] items-center justify-center whitespace-nowrap rounded-xl border border-storm/10 bg-white px-3 py-2 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </div>
-        ) : null}
       </nav>
     </header>
   );
@@ -194,103 +68,6 @@ function NavLink({ item, pathname }: NavLinkProps) {
     >
       {item.label}
     </Link>
-  );
-}
-
-type ProductMenuProps = {
-  menu: ProductMenuState;
-  onToggle: () => void;
-  onClose: () => void;
-  buttonRef: MutableRefObject<HTMLButtonElement | null>;
-  menuRef: MutableRefObject<HTMLDivElement | null>;
-  itemRefs: MutableRefObject<(HTMLAnchorElement | null)[]>;
-  pathname: string;
-};
-
-function ProductMenu({
-  menu,
-  onToggle,
-  onClose,
-  buttonRef,
-  menuRef,
-  itemRefs,
-  pathname,
-}: ProductMenuProps) {
-  return (
-    <div className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-storm/15 bg-white/80 px-3 py-1.5 text-[0.95rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-        aria-haspopup="true"
-        aria-expanded={menu.open}
-        aria-controls="desktop-product-menu"
-        onClick={() => onToggle()}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowDown" && !menu.open) {
-            event.preventDefault();
-            onToggle();
-          }
-        }}
-      >
-        Products
-        <svg
-          aria-hidden="true"
-          className={cn(
-            "h-4 w-4 transition-transform",
-            menu.open ? "rotate-180" : "rotate-0",
-          )}
-          viewBox="0 0 20 20"
-          fill="none"
-        >
-          <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
-        </svg>
-      </button>
-      {menu.open ? (
-        <div
-          ref={menuRef}
-          id="desktop-product-menu"
-          role="menu"
-          aria-label="Products"
-          className="absolute left-0 top-full z-50 mt-3 w-[320px] rounded-2xl border border-storm/10 bg-white p-3 shadow-[0_22px_60px_rgba(11,18,32,0.14)]"
-        >
-          <ul className="space-y-1">
-            {productNavigation.map((item, index) => {
-              const itemPath = getPathname(item.href);
-              const isActive = pathname === itemPath;
-              return (
-                <li key={item.href}>
-                  <Link
-                    ref={(node) => {
-                      itemRefs.current[index] = node;
-                    }}
-                    href={item.href}
-                    role="menuitem"
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "flex flex-col gap-1 rounded-xl px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                      isActive
-                        ? "bg-pastel-lagoon/60 text-storm"
-                        : "hover:bg-mist/60 text-storm/80 hover:text-storm",
-                    )}
-                    onClick={() => {
-                      onClose();
-                    }}
-                  >
-                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
-                    {item.description ? (
-                      <span className="text-[0.8rem] text-thunder/75">
-                        {item.description}
-                      </span>
-                    ) : null}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ) : null}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- simplify the header navigation by removing the Products dropdown controls
- rely on the primary navigation list for both desktop and mobile product links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68d0b8789854832d86f2a3a1cb2b6f85