### PR TITLE
Fix header product menu merge regression

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -18,6 +18,7 @@ const CTA = {
 };
 
 const PRODUCT_PATH = "/product" as const;
+
 export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
@@ -38,6 +39,7 @@ export default function Header() {
       open: true,
       focusIndex: prev.open ? prev.focusIndex : 0,
     }));
+
   const closeProductMenu = () => {
     keepMenuOpenOnProductRef.current = false;
     setMenu({ open: false, focusIndex: 0 });
@@ -56,8 +58,6 @@ export default function Header() {
       if (menuRef.current?.contains(event.target as Node)) return;
       if (desktopButtonRef.current?.contains(event.target as Node)) return;
       closeProductMenu();
-      keepMenuOpenOnProductRef.current = false;
-      setMenu({ open: false, focusIndex: 0 });
     }
 
     function handleKey(event: KeyboardEvent) {
@@ -66,8 +66,6 @@ export default function Header() {
       if (event.key === "Escape") {
         event.preventDefault();
         closeProductMenu();
-        keepMenuOpenOnProductRef.current = false;
-        setMenu({ open: false, focusIndex: 0 });
         desktopButtonRef.current?.focus();
         return;
       }
@@ -113,56 +111,6 @@ export default function Header() {
 
     keepMenuOpenOnProductRef.current = false;
   }, [pathname, productPath]);
-    setMenu((prev) => {
-      if (keepMenuOpenOnProductRef.current && pathname === productPath) {
-        return { open: true, focusIndex: prev.focusIndex ?? 0 };
-      }
-
-      return { open: false, focusIndex: 0 };
-    });
-
-    setMobileProductsOpen((_prev) => {
-      if (keepMenuOpenOnProductRef.current && pathname === productPath) {
-        return true;
-      }
-
-      return false;
-    });
-
-    keepMenuOpenOnProductRef.current = false;
-  }, [pathname, productPath]);
-
-    const shouldKeepOpen = keepMenuOpenOnProductRef.current && pathname === productPath;
-
-    setMenu((prev) => {
-      if (shouldKeepOpen) {
-        return { open: true, focusIndex: prev.focusIndex };
-      }
-
-    setMobileProductsOpen(false);
-    setMenu((prev) => {
-      if (keepMenuOpenOnProductRef.current && pathname === productPath) {
-        keepMenuOpenOnProductRef.current = false;
-        return {
-          open: true,
-          focusIndex: prev.focusIndex ?? 0,
-        };
-      }
-
-      keepMenuOpenOnProductRef.current = false;
-
-      if (!prev.open && prev.focusIndex === 0) {
-        return prev;
-      }
-
-      return { open: false, focusIndex: 0 };
-    });
-
-    setMobileProductsOpen(shouldKeepOpen);
-
-    keepMenuOpenOnProductRef.current = false;
-  }, [pathname, productPath]);
-  }, [pathname]);
 
   useEffect(() => {
     if (menu.open) {
@@ -250,51 +198,6 @@ export default function Header() {
             </button>
             {mainNavigation.map((item) => (
               <LinkChip key={item.href} item={item} pathname={pathname} />
-        <div className="container mx-auto flex items-center gap-3 overflow-x-auto px-5">
-          <button
-            ref={mobileButtonRef}
-            type="button"
-            aria-haspopup="true"
-            aria-expanded={mobileProductsOpen}
-            aria-controls="mobile-products"
-            className="inline-flex items-center whitespace-nowrap rounded-full border border-storm/15 bg-white px-3 py-1.5 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
-            onClick={() => {
-              navigateToProduct();
-              setMobileProductsOpen((prev) => !prev);
-            }}
-          >
-            Products
-            <span className="ml-2 inline-flex h-4 w-4 items-center justify-center">
-              <svg
-                aria-hidden="true"
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  mobileProductsOpen ? "rotate-180" : "rotate-0",
-                )}
-                viewBox="0 0 20 20"
-                fill="none"
-              >
-                <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
-              </svg>
-            </span>
-          </button>
-          {primaryNavigation.map((item) => (
-            <LinkChip key={item.href} item={item} pathname={pathname} />
-          ))}
-        </div>
-        {mobileProductsOpen ? (
-          <div
-            id="mobile-products"
-            className="container mx-auto mt-3 flex flex-wrap gap-3 px-5"
-          >
-            {productNavigation.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="inline-flex flex-1 min-w-[140px] items-center justify-center whitespace-nowrap rounded-xl border border-storm/10 bg-white px-3 py-2 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
-              >
-                {item.label}
-              </Link>
             ))}
           </div>
 


### PR DESCRIPTION
## Summary
- clean up the header product menu state after the bad merge removed necessary guards
- ensure the desktop and mobile product menus stay in sync when navigating to the product page
- keep the mobile navigation rendering consistent by removing duplicated markup

## Testing
- pnpm run lint
- CI=1 pnpm run build

------
https://chatgpt.com/codex/tasks/task_b_68d0e8909464832d863eeb1c77fca269