### PR TITLE
Update navigation and hero layouts

### DIFF
--- a/app/(site)/digital-legacy/page.tsx
+++ b/app/(site)/digital-legacy/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { AnalyticsEvent } from "@/components/analytics-event";
+import { DeviceMock } from "@/components/device-mock";
 import { SectionIntro } from "@/components/section-intro";
 import { PrimarySubtleLink, buttonClasses } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -95,36 +96,90 @@ export default function DigitalLegacyPage() {
           className="pointer-events-none absolute -right-24 top-12 h-80 w-80 rounded-full bg-pastel-lapis/50 blur-[160px]"
           aria-hidden="true"
         />
-        <div className="container relative space-y-8">
-          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
-            Digital Legacy
-          </p>
-          <h1 className="text-display font-semibold text-storm">
-            Digital Legacy, by Torvus
-          </h1>
-          <p className="max-w-prose text-lead text-thunder">
-            A privacy-first digital estate platform that inventories assets, verifies
-            executors, and releases information only when your policy says it’s time.
-          </p>
-          <div className="flex flex-wrap items-center gap-3">
-            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
-              Join the waitlist
-            </PrimarySubtleLink>
-            <Link
-              href="/pricing"
-              className={buttonClasses({
-                variant: "secondary",
-                size: "sm",
-                className: "border-lagoon/45 text-lagoon",
-              })}
-            >
-              Compare tiers
-            </Link>
+        <div className="container relative">
+          <div className="mx-auto flex w-full flex-col items-center gap-12 lg:max-w-none lg:flex-row lg:items-stretch lg:justify-center">
+            <div className="flex w-full lg:max-w-[560px] lg:flex-1">
+              <div className="flex h-full w-full flex-col gap-6 rounded-2xl border border-white/60 bg-white/90 p-8 shadow-[0_22px_60px_rgba(11,18,32,0.12)] backdrop-blur-sm">
+                <div className="space-y-4">
+                  <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+                    Digital Legacy
+                  </p>
+                  <h1 className="text-display font-semibold text-storm">
+                    Digital Legacy, by Torvus
+                  </h1>
+                  <p className="max-w-prose text-lead text-thunder">
+                    A privacy-first digital estate platform that inventories assets,
+                    verifies executors, and releases information only when your policy
+                    says it’s time.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+                    Join the waitlist
+                  </PrimarySubtleLink>
+                  <Link
+                    href="/pricing"
+                    className={buttonClasses({
+                      variant: "secondary",
+                      size: "sm",
+                      className: "border-lagoon/45 text-lagoon",
+                    })}
+                  >
+                    Compare tiers
+                  </Link>
+                </div>
+                <p className="max-w-prose text-[0.95rem] text-thunder">
+                  Executors and beneficiaries always receive provenance records. Torvus
+                  operators never see your plaintext.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex w-full flex-col items-center gap-8 lg:max-w-[480px] lg:flex-1 lg:justify-center">
+              <div className="flex w-full flex-1 items-center justify-center">
+                <DeviceMock />
+              </div>
+              <div className="w-full max-w-[340px] space-y-4 rounded-2xl border border-storm/10 bg-white/95 p-6 shadow-soft-1 lg:self-center">
+                <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
+                  Estate orchestrator
+                </p>
+                <h2 className="text-h4 font-semibold text-storm">
+                  Executors receive policy-backed checklists with provenance.
+                </h2>
+                <ul className="space-y-2 text-[0.95rem] text-thunder">
+                  <li className="flex gap-3">
+                    <span
+                      className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lapis"
+                      aria-hidden="true"
+                    />
+                    <span>
+                      Per-recipient bundles with redaction controls before anything
+                      unlocks.
+                    </span>
+                  </li>
+                  <li className="flex gap-3">
+                    <span
+                      className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                      aria-hidden="true"
+                    />
+                    <span>
+                      Verified executors complete step-by-step check-ins monitored by
+                      Torvus.
+                    </span>
+                  </li>
+                  <li className="flex gap-3">
+                    <span
+                      className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-cranberry"
+                      aria-hidden="true"
+                    />
+                    <span>
+                      All actions produce tamper-evident provenance certificates.
+                    </span>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
-          <p className="max-w-prose text-[0.95rem] text-thunder">
-            Executors and beneficiaries always receive provenance records. Torvus
-            operators never see your plaintext.
-          </p>
         </div>
       </section>
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState, type MutableRefObject } from "react";
+import { usePathname } from "next/navigation";
 
 import BrandLogo from "@/components/brand";
-import {
-  primaryNavigation,
-  productNavigation,
-  type NavigationLink,
-} from "@/lib/navigation";
+import { primaryNavigation, type NavigationLink } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 const CTA = {
@@ -17,110 +12,8 @@ const CTA = {
   label: "Join the waitlist",
 };
 
-const PRODUCT_PATH = "/product" as const;
-
 export default function Header() {
   const pathname = usePathname();
-  const router = useRouter();
-  const [menu, setMenu] = useState<ProductMenuState>({ open: false, focusIndex: 0 });
-  const [mobileProductsOpen, setMobileProductsOpen] = useState(false);
-
-  const desktopButtonRef = useRef<HTMLButtonElement | null>(null);
-  const mobileButtonRef = useRef<HTMLButtonElement | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
-  const keepMenuOpenOnProductRef = useRef(false);
-
-  const productPath = PRODUCT_PATH;
-  const mainNavigation = primaryNavigation.filter((item) => item.href !== productPath);
-
-  const openProductMenu = () =>
-    setMenu((prev) => ({
-      open: true,
-      focusIndex: prev.open ? prev.focusIndex : 0,
-    }));
-
-  const closeProductMenu = () => {
-    keepMenuOpenOnProductRef.current = false;
-    setMenu({ open: false, focusIndex: 0 });
-  };
-
-  const navigateToProduct = () => {
-    keepMenuOpenOnProductRef.current = true;
-    if (pathname !== productPath) {
-      router.push(productPath);
-    }
-  };
-
-  useEffect(() => {
-    function handleClick(event: MouseEvent) {
-      if (!menu.open) return;
-      if (menuRef.current?.contains(event.target as Node)) return;
-      if (desktopButtonRef.current?.contains(event.target as Node)) return;
-      closeProductMenu();
-    }
-
-    function handleKey(event: KeyboardEvent) {
-      if (!menu.open) return;
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeProductMenu();
-        desktopButtonRef.current?.focus();
-        return;
-      }
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setMenu((prev) => {
-          const nextIndex = (prev.focusIndex + 1) % productNavigation.length;
-          itemRefs.current[nextIndex]?.focus();
-          return { open: true, focusIndex: nextIndex };
-        });
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setMenu((prev) => {
-          const nextIndex =
-            (prev.focusIndex - 1 + productNavigation.length) % productNavigation.length;
-          itemRefs.current[nextIndex]?.focus();
-          return { open: true, focusIndex: nextIndex };
-        });
-      }
-    }
-
-    window.addEventListener("mousedown", handleClick);
-    window.addEventListener("keydown", handleKey);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [menu.open]);
-
-  useEffect(() => {
-    const shouldKeepOpen = keepMenuOpenOnProductRef.current && pathname === productPath;
-
-    setMenu((prev) =>
-      shouldKeepOpen
-        ? { open: true, focusIndex: prev.focusIndex ?? 0 }
-        : { open: false, focusIndex: 0 },
-    );
-
-    setMobileProductsOpen(shouldKeepOpen);
-
-    keepMenuOpenOnProductRef.current = false;
-  }, [pathname, productPath]);
-
-  useEffect(() => {
-    if (menu.open) {
-      const index = menu.focusIndex ?? 0;
-      const target = itemRefs.current[index];
-      target?.focus();
-    } else {
-      itemRefs.current = [];
-    }
-  }, [menu.open, menu.focusIndex]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/65">
@@ -128,18 +21,7 @@ export default function Header() {
         <BrandLogo />
 
         <nav className="hidden items-center gap-6 lg:flex" aria-label="Primary">
-          <ProductMenu
-            menu={menu}
-            onOpen={openProductMenu}
-            onClose={closeProductMenu}
-            onProductNavigate={navigateToProduct}
-            productHref={productPath}
-            buttonRef={desktopButtonRef}
-            menuRef={menuRef}
-            itemRefs={itemRefs}
-            pathname={pathname}
-          />
-          {mainNavigation.map((item) => (
+          {primaryNavigation.map((item) => (
             <NavLink key={item.href} item={item} pathname={pathname} />
           ))}
         </nav>
@@ -158,96 +40,15 @@ export default function Header() {
       >
         <div className="container mx-auto flex flex-col gap-3 px-5">
           <div className="flex items-center gap-3 overflow-x-auto">
-            <button
-              ref={mobileButtonRef}
-              type="button"
-              aria-haspopup="true"
-              aria-expanded={mobileProductsOpen}
-              aria-controls="mobile-products"
-              className="inline-flex items-center whitespace-nowrap rounded-full border border-storm/15 bg-white px-3 py-1.5 text-[0.9rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm"
-              onClick={() => {
-                setMobileProductsOpen((prev) => {
-                  const next = !prev;
-                  if (next) {
-                    navigateToProduct();
-                  } else {
-                    keepMenuOpenOnProductRef.current = false;
-                  }
-                  return next;
-                });
-              }}
-            >
-              Products
-              <span className="ml-2 inline-flex h-4 w-4 items-center justify-center">
-                <svg
-                  aria-hidden="true"
-                  className={cn(
-                    "h-4 w-4 transition-transform",
-                    mobileProductsOpen ? "rotate-180" : "rotate-0",
-                  )}
-                  viewBox="0 0 20 20"
-                  fill="none"
-                >
-                  <path
-                    d="M5 7.5 10 12.5 15 7.5"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                  />
-                </svg>
-              </span>
-            </button>
-            {mainNavigation.map((item) => (
+            {primaryNavigation.map((item) => (
               <LinkChip key={item.href} item={item} pathname={pathname} />
             ))}
           </div>
-
-          {mobileProductsOpen ? (
-            <div
-              id="mobile-products"
-              role="menu"
-              aria-label="Products"
-              className="grid gap-2 rounded-2xl border border-storm/10 bg-white p-3 shadow-sm"
-            >
-              {productNavigation.map((item) => {
-                const itemPath = getPathname(item.href);
-                const isActive = pathname === itemPath;
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    role="menuitem"
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "flex flex-col gap-1 rounded-xl px-3 py-2 text-left transition",
-                      isActive
-                        ? "bg-pastel-lagoon/60 text-storm"
-                        : "text-storm/80 hover:bg-mist/60 hover:text-storm",
-                    )}
-                    onClick={() => {
-                      setMobileProductsOpen(false);
-                    }}
-                  >
-                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
-                    {item.description ? (
-                      <span className="text-[0.8rem] text-thunder/75">
-                        {item.description}
-                      </span>
-                    ) : null}
-                  </Link>
-                );
-              })}
-            </div>
-          ) : null}
         </div>
       </nav>
     </header>
   );
 }
-
-type ProductMenuState = {
-  open: boolean;
-  focusIndex: number;
-};
 
 type NavLinkProps = {
   item: NavigationLink;
@@ -293,111 +94,6 @@ function LinkChip({ item, pathname }: LinkChipProps) {
     >
       {item.label}
     </Link>
-  );
-}
-
-type ProductMenuProps = {
-  menu: ProductMenuState;
-  onOpen: () => void;
-  onClose: () => void;
-  onProductNavigate: () => void;
-  productHref: string;
-  buttonRef: MutableRefObject<HTMLButtonElement | null>;
-  menuRef: MutableRefObject<HTMLDivElement | null>;
-  itemRefs: MutableRefObject<(HTMLAnchorElement | null)[]>;
-  pathname: string;
-};
-
-function ProductMenu({
-  menu,
-  onOpen,
-  onClose,
-  onProductNavigate,
-  productHref,
-  buttonRef,
-  menuRef,
-  itemRefs,
-  pathname,
-}: ProductMenuProps) {
-  return (
-    <div className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        data-href={productHref}
-        className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-storm/15 bg-white/80 px-3 py-1.5 text-[0.95rem] font-semibold text-storm/80 transition hover:border-lagoon/40 hover:text-storm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white"
-        aria-haspopup="true"
-        aria-expanded={menu.open}
-        aria-controls="desktop-product-menu"
-        onClick={() => {
-          onProductNavigate();
-          onOpen();
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowDown" && !menu.open) {
-            event.preventDefault();
-            onOpen();
-          }
-        }}
-      >
-        Products
-        <svg
-          aria-hidden="true"
-          className={cn(
-            "h-4 w-4 transition-transform",
-            menu.open ? "rotate-180" : "rotate-0",
-          )}
-          viewBox="0 0 20 20"
-          fill="none"
-        >
-          <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" strokeWidth="1.5" />
-        </svg>
-      </button>
-      {menu.open ? (
-        <div
-          ref={menuRef}
-          id="desktop-product-menu"
-          role="menu"
-          aria-label="Products"
-          className="absolute left-0 top-full z-50 mt-3 w-[320px] rounded-2xl border border-storm/10 bg-white p-3 shadow-[0_22px_60px_rgba(11,18,32,0.14)]"
-        >
-          <ul className="space-y-1">
-            {productNavigation.map((item, index) => {
-              const itemPath = getPathname(item.href);
-              const isActive = pathname === itemPath;
-              return (
-                <li key={item.href}>
-                  <Link
-                    ref={(node) => {
-                      itemRefs.current[index] = node;
-                    }}
-                    href={item.href}
-                    role="menuitem"
-                    aria-current={isActive ? "page" : undefined}
-                    className={cn(
-                      "flex flex-col gap-1 rounded-xl px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lagoon focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                      isActive
-                        ? "bg-pastel-lagoon/60 text-storm"
-                        : "text-storm/80 hover:bg-mist/60 hover:text-storm",
-                    )}
-                    onClick={() => {
-                      onClose();
-                    }}
-                  >
-                    <span className="text-[0.95rem] font-semibold">{item.label}</span>
-                    {item.description ? (
-                      <span className="text-[0.8rem] text-thunder/75">
-                        {item.description}
-                      </span>
-                    ) : null}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ) : null}
-    </div>
   );
 }
 

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -39,84 +39,91 @@ export function Hero() {
         aria-hidden="true"
       />
 
-      <div className="container relative grid gap-16 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)] lg:items-center">
-        <div className="space-y-7 rounded-2xl border border-white/60 bg-white/90 p-8 shadow-[0_22px_60px_rgba(11,18,32,0.12)] backdrop-blur-sm">
-          <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
-            Digital Legacy Kit
-          </p>
-          <h1 className="text-display font-semibold text-storm">
-            Preserve your intent and release it only when it truly matters.
-          </h1>
-          <p className="max-w-[60ch] text-lead text-thunder">
-            Torvus Digital Legacy seals assets, instructions, and crypto secrets behind
-            policy-orchestrated releases so executors only receive what you intend—after
-            verification and with provenance.
-          </p>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
-              Join the waitlist
-            </PrimarySubtleLink>
-            <Link
-              href="/digital-legacy"
-              className={buttonClasses({
-                variant: "tertiary",
-                size: "sm",
-                className: "border-lapis/45 text-lapis",
-              })}
-            >
-              Explore Digital Legacy
-            </Link>
+      <div className="container relative">
+        <div className="mx-auto flex w-full flex-col items-center gap-12 lg:max-w-none lg:flex-row lg:items-stretch lg:justify-center">
+          <div className="flex w-full lg:max-w-[560px] lg:flex-1">
+            <div className="flex h-full w-full flex-col space-y-7 rounded-2xl border border-white/60 bg-white/90 p-8 shadow-[0_22px_60px_rgba(11,18,32,0.12)] backdrop-blur-sm">
+              <p className="text-[0.9rem] font-semibold uppercase tracking-[0.26em] text-lapis">
+                Digital Legacy Kit
+              </p>
+              <h1 className="text-display font-semibold text-storm">
+                Preserve your intent and release it only when it truly matters.
+              </h1>
+              <p className="max-w-[60ch] text-lead text-thunder">
+                Torvus Digital Legacy seals assets, instructions, and crypto secrets
+                behind policy-orchestrated releases so executors only receive what you
+                intend—after verification and with provenance.
+              </p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <PrimarySubtleLink href="/waitlist" className="w-full sm:w-auto">
+                  Join the waitlist
+                </PrimarySubtleLink>
+                <Link
+                  href="/digital-legacy"
+                  className={buttonClasses({
+                    variant: "tertiary",
+                    size: "sm",
+                    className: "border-lapis/45 text-lapis",
+                  })}
+                >
+                  Explore Digital Legacy
+                </Link>
+              </div>
+              <p className="max-w-[60ch] text-[0.94rem] text-thunder">
+                Zero-knowledge encryption, duress controls, and executors with verified
+                identities. No plaintext ever leaves your vault without the conditions you
+                set.
+              </p>
+              <div className="mt-6 grid gap-2 text-[0.92rem]">
+                {highlights.map((item) => (
+                  <IconChip key={item.copy} tone={item.tone} icon={item.icon}>
+                    {item.copy}
+                  </IconChip>
+                ))}
+              </div>
+            </div>
           </div>
-          <p className="max-w-[60ch] text-[0.94rem] text-thunder">
-            Zero-knowledge encryption, duress controls, and executors with verified
-            identities. No plaintext ever leaves your vault without the conditions you
-            set.
-          </p>
-          <div className="mt-6 grid gap-2 text-[0.92rem]">
-            {highlights.map((item) => (
-              <IconChip key={item.copy} tone={item.tone} icon={item.icon}>
-                {item.copy}
-              </IconChip>
-            ))}
-          </div>
-        </div>
 
-        <div className="flex flex-col items-center gap-8">
-          <DeviceMock />
-          <div className="w-full max-w-[340px] space-y-4 rounded-2xl border border-storm/10 bg-white/95 p-6 shadow-soft-1">
-            <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
-              Estate orchestrator
-            </p>
-            <h2 className="text-h4 font-semibold text-storm">
-              Executors receive policy-backed checklists with provenance.
-            </h2>
-            <ul className="space-y-2 text-[0.95rem] text-thunder">
-              <li className="flex gap-3">
-                <span
-                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lapis"
-                  aria-hidden="true"
-                />
-                <span>
-                  Per-recipient bundles with redaction controls before anything unlocks.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span
-                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
-                  aria-hidden="true"
-                />
-                <span>
-                  Verified executors complete step-by-step check-ins monitored by Torvus.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span
-                  className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-cranberry"
-                  aria-hidden="true"
-                />
-                <span>All actions produce tamper-evident provenance certificates.</span>
-              </li>
-            </ul>
+          <div className="flex w-full flex-col items-center gap-8 lg:max-w-[480px] lg:flex-1 lg:justify-center">
+            <div className="flex w-full flex-1 items-center justify-center">
+              <DeviceMock />
+            </div>
+            <div className="w-full max-w-[340px] space-y-4 rounded-2xl border border-storm/10 bg-white/95 p-6 shadow-soft-1 lg:self-center">
+              <p className="text-[0.8rem] font-semibold uppercase tracking-[0.3em] text-lapis">
+                Estate orchestrator
+              </p>
+              <h2 className="text-h4 font-semibold text-storm">
+                Executors receive policy-backed checklists with provenance.
+              </h2>
+              <ul className="space-y-2 text-[0.95rem] text-thunder">
+                <li className="flex gap-3">
+                  <span
+                    className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lapis"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    Per-recipient bundles with redaction controls before anything unlocks.
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span
+                    className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-lagoon"
+                    aria-hidden="true"
+                  />
+                  <span>
+                    Verified executors complete step-by-step check-ins monitored by
+                    Torvus.
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span
+                    className="mt-[0.4rem] inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-cranberry"
+                    aria-hidden="true"
+                  />
+                  <span>All actions produce tamper-evident provenance certificates.</span>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/components/phone-mock.tsx
+++ b/components/phone-mock.tsx
@@ -33,10 +33,14 @@ export function PhoneMock({
   const bezel = scheme === "dark" ? "#D9DEE5" : "#E4E8EE";
   const cardBg = scheme === "dark" ? "rgba(7,12,22,0.92)" : "rgba(255,255,255,0.92)";
   const tint = scheme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.05)";
+  const NARROW_SCREEN_INSET = 48;
+  const WIDE_SCREEN_INSET = 44;
   const dimensions = narrow
     ? "h-[560px] w-[260px] md:h-[600px] md:w-[280px]"
     : "h-[480px] w-[280px] md:h-[520px] md:w-[300px]";
-  const screenInset = narrow ? "inset-[48px]" : "inset-[44px]";
+  const screenInset = narrow
+    ? `inset-[${NARROW_SCREEN_INSET}px]`
+    : `inset-[${WIDE_SCREEN_INSET}px]`;
 
   return (
     <div

--- a/components/phone-mock.tsx
+++ b/components/phone-mock.tsx
@@ -33,6 +33,10 @@ export function PhoneMock({
   const bezel = scheme === "dark" ? "#D9DEE5" : "#E4E8EE";
   const cardBg = scheme === "dark" ? "rgba(7,12,22,0.92)" : "rgba(255,255,255,0.92)";
   const tint = scheme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.05)";
+  const dimensions = narrow
+    ? "h-[560px] w-[260px] md:h-[600px] md:w-[280px]"
+    : "h-[480px] w-[280px] md:h-[520px] md:w-[300px]";
+  const screenInset = narrow ? "inset-[48px]" : "inset-[44px]";
 
   return (
     <div
@@ -40,8 +44,7 @@ export function PhoneMock({
       role="img"
       className={cn(
         "relative mx-auto",
-        narrow ? "h-[600px] w-[280px]" : "h-[520px] w-[320px]",
-        "md:h-[620px] md:w-[300px]",
+        dimensions,
         "animate-[float_10s_ease-in-out_infinite]",
       )}
     >
@@ -157,7 +160,12 @@ export function PhoneMock({
       </svg>
 
       {src ? (
-        <div className="pointer-events-none absolute inset-[52px] z-10 overflow-hidden rounded-[22px]">
+        <div
+          className={cn(
+            "pointer-events-none absolute z-10 overflow-hidden rounded-[22px]",
+            screenInset,
+          )}
+        >
           <Image
             src={src}
             alt={alt ?? ariaLabel}
@@ -169,7 +177,12 @@ export function PhoneMock({
         </div>
       ) : null}
       {!src && children ? (
-        <div className="pointer-events-none absolute inset-[52px] z-10 flex h-[510px] w-[246px] items-center justify-center overflow-hidden rounded-[22px]">
+        <div
+          className={cn(
+            "pointer-events-none absolute z-10 flex h-full w-full items-center justify-center overflow-hidden rounded-[22px]",
+            screenInset,
+          )}
+        >
           {children}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- replace the header product dropdown with a direct "Product" navigation link for desktop and mobile
- redesign the home hero to align the text panel with the device mockup and tweak the phone mock spacing for better balance
- mirror the refreshed hero layout on the Digital Legacy page so the messaging card and device preview stay aligned responsively

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_68d0ecaab904832da9c8322476ecfcdc